### PR TITLE
Refactor models

### DIFF
--- a/packages/web3/src/api/index.ts
+++ b/packages/web3/src/api/index.ts
@@ -43,3 +43,4 @@ export class ExplorerProvider extends ExplorerApi<null> {
 
 export * as node from './api-alephium'
 export * as explorer from './api-explorer'
+export * from './types'

--- a/packages/web3/src/api/types.ts
+++ b/packages/web3/src/api/types.ts
@@ -1,0 +1,233 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { assertType, bs58, Eq } from '../utils'
+import * as node from './api-alephium'
+
+export type Number256 = number | bigint | string
+export type Val = Number256 | boolean | string | Val[]
+export type NamedVals = Record<string, Val>
+
+export interface Token {
+  id: string
+  amount: Number256
+}
+assertType<Eq<keyof Token, keyof node.Token>>
+
+export function toApiToken(token: Token): node.Token {
+  return { id: token.id, amount: toApiNumber256(token.amount) }
+}
+
+export function toApiTokens(tokens?: Token[]): node.Token[] | undefined {
+  return tokens?.map(toApiToken)
+}
+
+export function fromApiToken(token: node.Token): Token {
+  return { id: token.id, amount: fromApiNumber256(token.amount) }
+}
+
+export function fromApiTokens(tokens?: node.Token[]): Token[] | undefined {
+  return tokens?.map(fromApiToken)
+}
+
+export function toApiBoolean(v: Val): boolean {
+  if (typeof v === 'boolean') {
+    return v
+  } else {
+    throw new Error(`Invalid boolean value: ${v}`)
+  }
+}
+
+// TODO: check integer bounds
+export function toApiNumber256(v: Val): string {
+  if ((typeof v === 'number' && Number.isInteger(v)) || typeof v === 'bigint') {
+    return v.toString()
+  } else if (typeof v === 'string') {
+    return v
+  } else {
+    throw new Error(`Invalid 256 bit number: ${v}`)
+  }
+}
+
+export function toApiNumber256Optional(v?: Val): string | undefined {
+  return v === undefined ? undefined : toApiNumber256(v)
+}
+
+export function fromApiNumber256(n: string): Number256 {
+  if (Number.isSafeInteger(Number.parseInt(n))) {
+    return Number(n)
+  } else {
+    return BigInt(n)
+  }
+}
+
+// TODO: check hex string
+export function toApiByteVec(v: Val): string {
+  if (typeof v === 'string') {
+    // try to convert from address to contract id
+    try {
+      const address = bs58.decode(v)
+      if (address.length == 33 && address[0] == 3) {
+        return Buffer.from(address.slice(1)).toString('hex')
+      }
+    } catch (_) {
+      return v as string
+    }
+    return v as string
+  } else {
+    throw new Error(`Invalid string: ${v}`)
+  }
+}
+
+export function toApiAddress(v: Val): string {
+  if (typeof v === 'string') {
+    try {
+      bs58.decode(v)
+      return v as string
+    } catch (error) {
+      throw new Error(`Invalid base58 string: ${v}`)
+    }
+  } else {
+    throw new Error(`Invalid string: ${v}`)
+  }
+}
+
+export function toApiArray(tpe: string, v: Val): node.Val {
+  if (!Array.isArray(v)) {
+    throw new Error(`Expected array, got ${v}`)
+  }
+
+  const semiColonIndex = tpe.lastIndexOf(';')
+  if (semiColonIndex == -1) {
+    throw new Error(`Invalid Val type: ${tpe}`)
+  }
+
+  const subType = tpe.slice(1, semiColonIndex)
+  const dim = parseInt(tpe.slice(semiColonIndex + 1, -1))
+  if ((v as Val[]).length != dim) {
+    throw new Error(`Invalid val dimension: ${v}`)
+  } else {
+    return { value: (v as Val[]).map((v) => toApiVal(v, subType)), type: 'Array' }
+  }
+}
+
+export function toApiVal(v: Val, tpe: string): node.Val {
+  if (tpe === 'Bool') {
+    return { value: toApiBoolean(v), type: tpe }
+  } else if (tpe === 'U256' || tpe === 'I256') {
+    return { value: toApiNumber256(v), type: tpe }
+  } else if (tpe === 'ByteVec') {
+    return { value: toApiByteVec(v), type: tpe }
+  } else if (tpe === 'Address') {
+    return { value: toApiAddress(v), type: tpe }
+  } else {
+    return toApiArray(tpe, v)
+  }
+}
+
+function _fromApiVal(vals: node.Val[], valIndex: number, tpe: string): [result: Val, nextIndex: number] {
+  if (vals.length === 0) {
+    throw new Error('Not enough Vals')
+  }
+
+  const firstVal = vals[`${valIndex}`]
+  if (tpe === 'Bool' && firstVal.type === tpe) {
+    return [firstVal.value as boolean, valIndex + 1]
+  } else if ((tpe === 'U256' || tpe === 'I256') && firstVal.type === tpe) {
+    return [fromApiNumber256(firstVal.value as string), valIndex + 1]
+  } else if ((tpe === 'ByteVec' || tpe === 'Address') && firstVal.type === tpe) {
+    return [firstVal.value as string, valIndex + 1]
+  } else {
+    const [baseType, dims] = decodeArrayType(tpe)
+    const arraySize = dims.reduce((a, b) => a * b)
+    const nextIndex = valIndex + arraySize
+    const valsToUse = vals.slice(valIndex, nextIndex)
+    if (valsToUse.length == arraySize && valsToUse.every((val) => val.type === baseType)) {
+      const localVals = valsToUse.map((val) => fromApiVal(val, baseType))
+      return [foldVals(localVals, dims), nextIndex]
+    } else {
+      throw new Error(`Invalid array Val type: ${valsToUse}, ${tpe}`)
+    }
+  }
+}
+
+export function fromApiVals(vals: node.Val[], names: string[], types: string[]): NamedVals {
+  let valIndex = 0
+  const result: NamedVals = {}
+  types.forEach((currentType, index) => {
+    const currentName = names[`${index}`]
+    const [val, nextIndex] = _fromApiVal(vals, valIndex, currentType)
+    valIndex = nextIndex
+    result[`${currentName}`] = val
+  })
+  return result
+}
+
+export function fromApiArray(vals: node.Val[], types: string[]): Val[] {
+  let valIndex = 0
+  const result: Val[] = []
+  for (const currentType of types) {
+    const [val, nextIndex] = _fromApiVal(vals, valIndex, currentType)
+    result.push(val)
+    valIndex = nextIndex
+  }
+  return result
+}
+
+export function fromApiVal(v: node.Val, tpe: string): Val {
+  if (v.type === 'Bool' && v.type === tpe) {
+    return v.value as boolean
+  } else if ((v.type === 'U256' || v.type === 'I256') && v.type === tpe) {
+    return fromApiNumber256(v.value as string)
+  } else if ((v.type === 'ByteVec' || v.type === 'Address') && v.type === tpe) {
+    return v.value as string
+  } else {
+    throw new Error(`Invalid node.Val type: ${v}`)
+  }
+}
+
+function decodeArrayType(tpe: string): [baseType: string, dims: number[]] {
+  const semiColonIndex = tpe.lastIndexOf(';')
+  if (semiColonIndex === -1) {
+    throw new Error(`Invalid Val type: ${tpe}`)
+  }
+
+  const subType = tpe.slice(1, semiColonIndex)
+  const dim = parseInt(tpe.slice(semiColonIndex + 1, -1))
+  if (subType[0] == '[') {
+    const [baseType, subDim] = decodeArrayType(subType)
+    return [baseType, (subDim.unshift(dim), subDim)]
+  } else {
+    return [subType, [dim]]
+  }
+}
+
+function foldVals(vals: Val[], dims: number[]): Val {
+  if (dims.length == 1) {
+    return vals
+  } else {
+    const result: Val[] = []
+    const chunkSize = vals.length / dims[0]
+    const chunkDims = dims.slice(1)
+    for (let i = 0; i < vals.length; i += chunkSize) {
+      const chunk = vals.slice(i, i + chunkSize)
+      result.push(foldVals(chunk, chunkDims))
+    }
+    return result
+  }
+}

--- a/packages/web3/src/contract/events.ts
+++ b/packages/web3/src/contract/events.ts
@@ -16,14 +16,14 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { ContractEvent } from '../api/api-alephium'
+import { node } from '../api'
 import { Subscription, SubscribeOptions } from '../utils'
 
-export class EventSubscription extends Subscription<ContractEvent> {
+export class EventSubscription extends Subscription<node.ContractEvent> {
   readonly contractAddress: string
   private fromCount: number
 
-  constructor(options: SubscribeOptions<ContractEvent>, contractAddress: string, fromCount?: number) {
+  constructor(options: SubscribeOptions<node.ContractEvent>, contractAddress: string, fromCount?: number) {
     super(options)
     this.contractAddress = contractAddress
     this.fromCount = typeof fromCount === 'undefined' ? 0 : fromCount
@@ -67,7 +67,7 @@ export class EventSubscription extends Subscription<ContractEvent> {
 }
 
 export function subscribeToEvents(
-  options: SubscribeOptions<ContractEvent>,
+  options: SubscribeOptions<node.ContractEvent>,
   contractAddress: string,
   fromCount?: number
 ): EventSubscription {

--- a/packages/web3/src/contract/ralph.test.ts
+++ b/packages/web3/src/contract/ralph.test.ts
@@ -16,10 +16,9 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { node } from '../api'
 import * as ralph from './ralph'
 import * as utils from '../utils'
-import { Fields } from './contract'
+import { Fields, FieldsSig } from './contract'
 
 describe('contract', function () {
   it('should encode I256', async () => {
@@ -132,7 +131,7 @@ describe('contract', function () {
 
   it('should test buildScriptByteCode', async () => {
     const variables = { x: true, y: 0x05, z: 'ff', a: '1C2RAVWSuaXw8xtUxqVERR7ChKBE1XgscNFw73NSHE1v3' }
-    const fieldsSig: node.FieldsSig = {
+    const fieldsSig: FieldsSig = {
       names: ['x', 'y', 'z', 'a'],
       types: ['Bool', 'U256', 'ByteVec', 'Address'],
       isMutable: [false, false, false, false]
@@ -149,7 +148,7 @@ describe('contract', function () {
       d: '1C2RAVWSuaXw8xtUxqVERR7ChKBE1XgscNFw73NSHE1v3',
       e: [false, true]
     }
-    const fieldsSig: node.FieldsSig = {
+    const fieldsSig: FieldsSig = {
       names: ['a', 'b', 'c', 'd', 'e'],
       types: ['I256', 'U256', 'ByteVec', 'Address', '[Bool;2]'],
       isMutable: [false, false, false, false]

--- a/packages/web3/src/contract/ralph.ts
+++ b/packages/web3/src/contract/ralph.ts
@@ -17,9 +17,9 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { Buffer } from 'buffer/'
+import { Val } from '../api'
 import { bs58, isHexString } from '../utils'
-import { node } from '../api'
-import { Fields, Val } from './contract'
+import { Fields, FieldsSig } from './contract'
 
 const bigIntZero = BigInt(0)
 
@@ -236,7 +236,7 @@ export function encodeScriptField(tpe: string, value: Val): Uint8Array {
 
 const scriptFieldRegex = /\{([0-9]*)\}/g
 
-export function buildScriptByteCode(bytecodeTemplate: string, fields: Fields, fieldsSig: node.FieldsSig): string {
+export function buildScriptByteCode(bytecodeTemplate: string, fields: Fields, fieldsSig: FieldsSig): string {
   return bytecodeTemplate.replace(scriptFieldRegex, (_, fieldIndex: string) => {
     const fieldName = fieldsSig.names[`${fieldIndex}`]
     const fieldType = fieldsSig.types[`${fieldIndex}`]
@@ -249,7 +249,7 @@ export function buildScriptByteCode(bytecodeTemplate: string, fields: Fields, fi
   })
 }
 
-export function buildContractByteCode(bytecode: string, fields: Fields, fieldsSig: node.FieldsSig): string {
+export function buildContractByteCode(bytecode: string, fields: Fields, fieldsSig: FieldsSig): string {
   const fieldsEncoded = fieldsSig.names.flatMap((fieldName, fieldIndex) => {
     const fieldType = fieldsSig.types[`${fieldIndex}`]
     if (fieldName in fields) {

--- a/packages/web3/src/transaction/status.ts
+++ b/packages/web3/src/transaction/status.ts
@@ -16,8 +16,10 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { TxStatus } from '../api/api-alephium'
+import { node } from '../api'
 import { Subscription, SubscribeOptions } from '../utils'
+
+export type TxStatus = node.TxStatus
 
 export class TxStatusSubscription extends Subscription<TxStatus> {
   readonly txId: string

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -22,6 +22,7 @@ import { node } from '@alephium/web3'
 import { testNodeWallet } from '@alephium/web3-wallet'
 import { SubscribeOptions, timeout } from '@alephium/web3'
 import { web3 } from '@alephium/web3'
+import { TxStatus } from '@alephium/web3'
 
 describe('transactions', function () {
   it('should subscribe transaction status', async () => {
@@ -34,11 +35,11 @@ describe('transactions', function () {
       initialTokenAmounts: []
     })
 
-    let txStatus: node.TxStatus | undefined = undefined
+    let txStatus: TxStatus | undefined = undefined
     let counter = 0
     const subscriptOptions: SubscribeOptions<node.TxStatus> = {
       pollingInterval: 500,
-      messageCallback: (status: node.TxStatus): Promise<void> => {
+      messageCallback: (status: TxStatus): Promise<void> => {
         txStatus = status
         counter = counter + 1
         return Promise.resolve()


### PR DESCRIPTION
* Move the common types from 'contract' to 'api'
* Expose models that are imported from node api