### PR TITLE
Refactor signer provider

### DIFF
--- a/packages/web3-test/src/index.ts
+++ b/packages/web3-test/src/index.ts
@@ -24,6 +24,7 @@ export const testMnemonic =
   'vault alarm sad mass witness property virus style good flower rice alpha viable evidence run glare pretty scout evil judge enroll refuse another lava'
 export const testWalletName = 'alephium-web3-test-only-wallet'
 export const testAddress = '1DrDyTr9RpRsQnDnXo2YRiPzPW4ooHX5LLoqXrqfMrpQH'
+export const testPrivateKey = 'a642942e67258589cd2b1822c631506632db5a12aabcf413604e785300d762a5'
 export const testPassword = 'alph'
 
 export async function testNodeWallet(): Promise<NodeWallet> {

--- a/packages/web3-wallet/src/privatekey-wallet.ts
+++ b/packages/web3-wallet/src/privatekey-wallet.ts
@@ -46,13 +46,13 @@ export class PrivateKeyWallet extends SignerProvider {
     this.nodeProvider = nodeProvider ?? web3.getCurrentNodeProvider()
   }
 
-  static Random(targetGroup?: number, alwaysSubmitTx = true, nodeProvider?: NodeProvider): PrivateKeyWallet {
+  static Random(targetGroup?: number, nodeProvider?: NodeProvider): PrivateKeyWallet {
     const keyPair = ec.genKeyPair()
     const wallet = new PrivateKeyWallet(keyPair.getPrivate().toString('hex'))
     if (targetGroup === undefined || wallet.group === targetGroup) {
       return wallet
     } else {
-      return PrivateKeyWallet.Random(targetGroup, alwaysSubmitTx, nodeProvider)
+      return PrivateKeyWallet.Random(targetGroup, nodeProvider)
     }
   }
 

--- a/packages/web3-wallet/src/privatekey-wallet.ts
+++ b/packages/web3-wallet/src/privatekey-wallet.ts
@@ -48,7 +48,7 @@ export class PrivateKeyWallet extends SignerProvider {
 
   static Random(targetGroup?: number, nodeProvider?: NodeProvider): PrivateKeyWallet {
     const keyPair = ec.genKeyPair()
-    const wallet = new PrivateKeyWallet(keyPair.getPrivate().toString('hex'))
+    const wallet = new PrivateKeyWallet(keyPair.getPrivate().toString('hex'), nodeProvider)
     if (targetGroup === undefined || wallet.group === targetGroup) {
       return wallet
     } else {

--- a/test/signer.test.ts
+++ b/test/signer.test.ts
@@ -1,0 +1,39 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { NodeProvider, SignerProviderWrapper } from '@alephium/web3'
+import { testPrivateKey } from '@alephium/web3-test'
+import { PrivateKeyWallet } from '@alephium/web3-wallet'
+
+describe('signer', () => {
+  it('should wrap a signer', async () => {
+    const fakeNodeProvider = new NodeProvider('https://8.8.8.8')
+    const signer = new PrivateKeyWallet(testPrivateKey, fakeNodeProvider)
+    const build = signer.buildTransferTx({
+      signerAddress: signer.address,
+      destinations: [{ address: signer.address, attoAlphAmount: 1e18 }]
+    })
+    expect(build).rejects.toThrow(/\[Node API Error\]/)
+
+    const signer1 = new SignerProviderWrapper(signer, new NodeProvider('http://127.0.0.1:22973'))
+    await signer1.buildTransferTx({
+      signerAddress: signer.address,
+      destinations: [{ address: signer.address, attoAlphAmount: 1e18 }]
+    })
+  })
+})


### PR DESCRIPTION
* Remove SingerProviderWithoutNodeProvider to make hierarchy simple

* Make SingerProvider.nodeProvider to be optional. Devs could check easily if the signer supports node provider methods

The design is more consistent with the design of WalletConnect and extension wallets.