### PR TITLE
Add remote node provider

### DIFF
--- a/packages/web3/src/api/index.ts
+++ b/packages/web3/src/api/index.ts
@@ -82,6 +82,39 @@ export class NodeProvider implements INodeProvider {
   }
 }
 
+export interface RequestArguments {
+  path: string
+  method: string
+  params?: any
+}
+
+export class RemoteNodeProvider implements INodeProvider {
+  readonly wallets!: NodeApi<string>['wallets']
+  readonly infos!: NodeApi<string>['infos']
+  readonly blockflow!: NodeApi<string>['blockflow']
+  readonly addresses!: NodeApi<string>['addresses']
+  readonly transactions!: NodeApi<string>['transactions']
+  readonly contracts!: NodeApi<string>['contracts']
+  readonly multisig!: NodeApi<string>['multisig']
+  readonly utils!: NodeApi<string>['utils']
+  readonly miners!: NodeApi<string>['miners']
+  readonly events!: NodeApi<string>['events']
+
+  constructor(request: (request: RequestArguments) => Promise<any>) {
+    const fakeNodeProvide = new NodeProvider('https://1.2.3.4:12973')
+    Object.assign(this, fakeNodeProvide) // Initialize the class
+
+    // Update class properties to forward requests
+    for (const [path, pathObject] of Object.entries(this)) {
+      for (const method of Object.keys(pathObject)) {
+        pathObject[`${method}`] = async (params: any): Promise<any> => {
+          return request({ path, method, params })
+        }
+      }
+    }
+  }
+}
+
 // TODO: use proxy provider once the endpoints are refined.
 export class ExplorerProvider extends ExplorerApi<null> {
   constructor(baseUrl: string) {

--- a/packages/web3/src/signer/signer.ts
+++ b/packages/web3/src/signer/signer.ts
@@ -53,9 +53,6 @@ export interface Account {
 export type SignerAddress = { signerAddress: string }
 type TxBuildParams<T> = Omit<T, 'fromPublicKey' | 'targetBlockHash'> & SignerAddress
 
-export type GetAccountsParams = undefined
-export type GetAccountsResult = Account[]
-
 export interface SignTransferTxParams {
   signerAddress: string
   destinations: Destination[]

--- a/test/node-provider.test.ts
+++ b/test/node-provider.test.ts
@@ -1,0 +1,33 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { RemoteNodeProvider, RequestArguments, web3 } from '../packages/web3/src'
+
+describe('remote node provider', () => {
+  it('forward requests', async () => {
+    web3.setCurrentNodeProvider('http://127.0.0.1:22973')
+    const nodeProvider = web3.getCurrentNodeProvider()
+    const request = async (args: RequestArguments): Promise<any> => {
+      const call = nodeProvider[args.path][args.method] as (any) => Promise<any>
+      return call(args.params)
+    }
+    const remoteNodeProvider = new RemoteNodeProvider(request)
+    console.log(await remoteNodeProvider.wallets.getWallets())
+    console.log(await remoteNodeProvider.infos.getInfosVersion())
+  })
+})


### PR DESCRIPTION
RemoteNodeProvider is added so that WalletConnect provider could forward RESTful requests.