### PR TITLE
Improve types

### DIFF
--- a/packages/cli/src/deployment.ts
+++ b/packages/cli/src/deployment.ts
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { Account, NodeProvider, Project, Contract, Script, node, web3, Token } from '@alephium/web3'
+import { Account, NodeProvider, Project, Contract, Script, node, web3, Token, Number256 } from '@alephium/web3'
 import { PrivateKeyWallet } from '@alephium/web3-wallet'
 import path from 'path'
 import fs, { promises as fsPromises } from 'fs'
@@ -155,7 +155,7 @@ function recordEqual(left: Record<string, string>, right: Record<string, string>
 async function needToRetry(
   provider: NodeProvider,
   previous: ExecutionResult | undefined,
-  attoAlphAmount: string | undefined,
+  attoAlphAmount: Number256 | undefined,
   tokens: Record<string, string> | undefined,
   codeHash: string
 ): Promise<boolean> {
@@ -175,9 +175,9 @@ async function needToRetry(
 async function needToDeployContract(
   provider: NodeProvider,
   previous: DeployContractResult | undefined,
-  attoAlphAmount: string | undefined,
+  attoAlphAmount: Number256 | undefined,
   tokens: Record<string, string> | undefined,
-  issueTokenAmount: string | undefined,
+  issueTokenAmount: Number256 | undefined,
   codeHash: string
 ): Promise<boolean> {
   const retry = await needToRetry(provider, previous, attoAlphAmount, tokens, codeHash)
@@ -191,7 +191,7 @@ async function needToDeployContract(
 async function needToRunScript(
   provider: NodeProvider,
   previous: RunScriptResult | undefined,
-  attoAlphAmount: string | undefined,
+  attoAlphAmount: Number256 | undefined,
   tokens: Record<string, string> | undefined,
   codeHash: string
 ): Promise<boolean> {
@@ -247,13 +247,12 @@ async function createDeployer<Settings = unknown>(
     const taskId = getTaskId(contract, taskTag)
     const previous = deployContractResults.get(taskId)
     const tokens = params.initialTokenAmounts ? getTokenRecord(params.initialTokenAmounts) : undefined
-    const issueTokenAmount: string | undefined = params.issueTokenAmount?.toString()
     const needToDeploy = await needToDeployContract(
       web3.getCurrentNodeProvider(),
       previous,
       params.initialAttoAlphAmount,
       tokens,
-      issueTokenAmount,
+      params.issueTokenAmount,
       codeHash
     )
     if (!needToDeploy) {
@@ -274,7 +273,7 @@ async function createDeployer<Settings = unknown>(
       codeHash: codeHash,
       attoAlphAmount: params.initialAttoAlphAmount,
       tokens: tokens,
-      issueTokenAmount: issueTokenAmount
+      issueTokenAmount: params.issueTokenAmount
     }
     deployContractResults.set(taskId, deployContractResult)
     return deployContractResult
@@ -289,7 +288,7 @@ async function createDeployer<Settings = unknown>(
     const needToRun = await needToRunScript(
       web3.getCurrentNodeProvider(),
       previous,
-      params.attoAlphAmount?.toString(),
+      params.attoAlphAmount,
       tokens,
       codeHash
     )
@@ -306,7 +305,7 @@ async function createDeployer<Settings = unknown>(
       txId: result.txId,
       blockHash: confirmed.blockHash,
       codeHash: codeHash,
-      attoAlphAmount: params.attoAlphAmount?.toString(),
+      attoAlphAmount: params.attoAlphAmount,
       tokens: tokens
     }
     runScriptResults.set(taskId, runScriptResult)

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -26,7 +26,8 @@ import {
   CompilerOptions,
   web3,
   Project,
-  DEFAULT_COMPILER_OPTIONS
+  DEFAULT_COMPILER_OPTIONS,
+  Number256
 } from '@alephium/web3'
 import { getConfigFile, loadConfig } from './utils'
 
@@ -107,14 +108,14 @@ export interface ExecutionResult {
   txId: string
   blockHash: string
   codeHash: string
-  attoAlphAmount?: string
+  attoAlphAmount?: Number256
   tokens?: Record<string, string>
 }
 
 export interface DeployContractResult extends ExecutionResult {
   contractId: string
   contractAddress: string
-  issueTokenAmount?: string
+  issueTokenAmount?: Number256
 }
 
 export type RunScriptResult = ExecutionResult

--- a/packages/cli/templates/base/alephium.config.ts
+++ b/packages/cli/templates/base/alephium.config.ts
@@ -5,7 +5,7 @@ import { Number256 } from '@alephium/web3'
 export type Settings = {
   issueTokenAmount: Number256
 }
-const defaultSettings: Settings = { issueTokenAmount: 100 }
+const defaultSettings: Settings = { issueTokenAmount: 100n }
 
 const configuration: Configuration<Settings> = {
   defaultNetwork: 'devnet',

--- a/packages/cli/templates/base/src/token.ts
+++ b/packages/cli/templates/base/src/token.ts
@@ -33,7 +33,7 @@ async function withdraw() {
 
     // Submit a transaction to use the transaction script
     const withdrawTX = await script.execute(signer, {
-      initialFields: { token: tokenId, amount: 1 }
+      initialFields: { token: tokenId, amount: 1n }
     })
 
     // Fetch the latest state of the token contract

--- a/packages/cli/templates/base/test/token.test.ts
+++ b/packages/cli/templates/base/test/token.test.ts
@@ -23,13 +23,13 @@ describe("unit tests", () => {
       // a random address that the test contract resides in the tests
       address: testContractAddress,
       // assets owned by the test contract before a test
-      initialAsset: { alphAmount: 1e18, tokens: [{id: testTokenId, amount: 10 }]},
+      initialAsset: { alphAmount: 10n ** 18n, tokens: [{id: testTokenId, amount: 10n }]},
       // initial state of the test contract
-      initialFields: { supply: 1e18, balance: 10 },
+      initialFields: { supply: 10n ** 18n, balance: 10n },
       // arguments to test the target function of the test contract
-      testArgs: { amount: 1 },
+      testArgs: { amount: 1n },
       // assets owned by the caller of the function
-      inputAssets: [{ address: testAddress, asset: { alphAmount: 1e18 } }]
+      inputAssets: [{ address: testAddress, asset: { alphAmount: 10n ** 18n } }]
     }
   })
 
@@ -40,11 +40,11 @@ describe("unit tests", () => {
     // only one contract involved in the test
     const contractState = testResult.contracts[0]
     expect(contractState.address).toEqual(testContractAddress)
-    expect(contractState.fields.supply).toEqual(BigInt(1e18))
+    expect(contractState.fields.supply).toEqual(10n ** 18n)
     // the balance of the test token is: 10 - 1 = 9
-    expect(contractState.fields.balance).toEqual(9)
+    expect(contractState.fields.balance).toEqual(9n)
     // double check the balance of the contract assets
-    expect(contractState.asset).toEqual({ alphAmount: BigInt(1e18), tokens: [{id: testTokenId, amount: 9 }]})
+    expect(contractState.asset).toEqual({ alphAmount: 10n ** 18n, tokens: [{id: testTokenId, amount: 9n }]})
 
     // two transaction outputs in total
     expect(testResult.txOutputs.length).toEqual(2)
@@ -53,17 +53,17 @@ describe("unit tests", () => {
     const callerOutput = testResult.txOutputs[0] as AssetOutput
     expect(callerOutput.type).toEqual('AssetOutput')
     expect(callerOutput.address).toEqual(testAddress)
-    expect(callerOutput.alphAmount).toBeLessThan(BigInt(1e18)) // the caller paid gas
+    expect(callerOutput.alphAmount).toBeLessThan(10n ** 18n) // the caller paid gas
     // the caller withdrawn 1 token from the contract
-    expect(callerOutput.tokens).toEqual([{ id: testTokenId, amount: 1 }])
+    expect(callerOutput.tokens).toEqual([{ id: testTokenId, amount: 1n }])
 
     // the second transaction output is for the contract
     const contractOutput = testResult.txOutputs[1]
     expect(contractOutput.type).toEqual('ContractOutput')
     expect(contractOutput.address).toEqual(testContractAddress)
-    expect(contractOutput.alphAmount).toEqual(BigInt(1e18))
+    expect(contractOutput.alphAmount).toEqual(10n ** 18n)
     // the contract has transferred 1 token to the caller
-    expect(contractOutput.tokens).toEqual([{ id: testTokenId, amount: 9 }])
+    expect(contractOutput.tokens).toEqual([{ id: testTokenId, amount: 9n }])
 
     // a `Withdraw` event is emitted when the test passes
     expect(testResult.events.length).toEqual(1)
@@ -75,7 +75,7 @@ describe("unit tests", () => {
     // the first field of the event
     expect(event.fields.to).toEqual(testAddress)
     // the second field of the event
-    expect(event.fields.amount).toEqual(1)
+    expect(event.fields.amount).toEqual(1n)
 
     // the test framework support debug messages too
     // debug will be disabled automatically at the deployment to real networks
@@ -83,7 +83,7 @@ describe("unit tests", () => {
   })
 
   it("test withdraw", async () => {
-    const testParams: TestContractParams = { ...testParamsFixture, testArgs: { amount: 3 } }
+    const testParams: TestContractParams = { ...testParamsFixture, testArgs: { amount: 3n } }
     // test that assertion failed in the withdraw function
     await expectAssertionError(token.testPublicMethod('withdraw', testParams), testContractAddress, 0)
   })
@@ -114,17 +114,17 @@ describe("integration tests", () => {
 
       const token = Contract.fromJson(tokenContractJson)
       const initialState = await token.fetchState(tokenAddress, testGroup)
-      const initialBalance = initialState.fields.balance as number
+      const initialBalance = initialState.fields.balance as bigint
 
       // Call `withdraw` function 10 times
       for (let i = 0; i < 10; i++) {
         const withdrawTX = await script.execute(signer, {
-          initialFields: { token: tokenId, amount: 1 }
+          initialFields: { token: tokenId, amount: 1n }
         })
 
         const newState = await token.fetchState(tokenAddress, testGroup)
-        const newBalance = newState.fields.balance as number
-        expect(newBalance).toEqual(initialBalance - i - 1)
+        const newBalance = newState.fields.balance as bigint
+        expect(newBalance).toEqual(initialBalance - BigInt(i) - 1n)
       }
     }
   }, 20000)

--- a/packages/web3/src/api/api-alephium.ts
+++ b/packages/web3/src/api/api-alephium.ts
@@ -201,7 +201,7 @@ export interface BrokerInfo {
   address: { addr: string; port: number }
 }
 
-export interface BuildDeployContractTx {
+export interface BuildDeployContractTx { 
   /** @format public-key */
   fromPublicKey: string
 

--- a/packages/web3/src/api/api-alephium.ts
+++ b/packages/web3/src/api/api-alephium.ts
@@ -201,7 +201,7 @@ export interface BrokerInfo {
   address: { addr: string; port: number }
 }
 
-export interface BuildDeployContractTx { 
+export interface BuildDeployContractTx {
   /** @format public-key */
   fromPublicKey: string
 

--- a/packages/web3/src/api/types.ts
+++ b/packages/web3/src/api/types.ts
@@ -68,12 +68,8 @@ export function toApiNumber256Optional(v?: Val): string | undefined {
   return v === undefined ? undefined : toApiNumber256(v)
 }
 
-export function fromApiNumber256(n: string): Number256 {
-  if (Number.isSafeInteger(Number.parseInt(n))) {
-    return Number(n)
-  } else {
-    return BigInt(n)
-  }
+export function fromApiNumber256(n: string): bigint {
+  return BigInt(n)
 }
 
 // TODO: check hex string

--- a/packages/web3/src/api/types.ts
+++ b/packages/web3/src/api/types.ts
@@ -19,7 +19,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import { assertType, bs58, Eq } from '../utils'
 import * as node from './api-alephium'
 
-export type Number256 = number | bigint | string
+export type Number256 = bigint
 export type Val = Number256 | boolean | string | Val[]
 export type NamedVals = Record<string, Val>
 

--- a/packages/web3/src/contract/contract.ts
+++ b/packages/web3/src/contract/contract.ts
@@ -816,11 +816,11 @@ export class Contract extends Artifact {
     const signerParams: SignDeployContractTxParams = {
       signerAddress: (await signer.getSelectedAccount()).address,
       bytecode: bytecode,
-      initialAttoAlphAmount: extractOptionalNumber256(params.initialAttoAlphAmount),
-      issueTokenAmount: extractOptionalNumber256(params.issueTokenAmount),
-      initialTokenAmounts: toApiTokens(params.initialTokenAmounts),
+      initialAttoAlphAmount: params.initialAttoAlphAmount,
+      issueTokenAmount: params.issueTokenAmount,
+      initialTokenAmounts: params.initialTokenAmounts,
       gasAmount: params.gasAmount,
-      gasPrice: extractOptionalNumber256(params.gasPrice)
+      gasPrice: params.gasPrice
     }
     return signerParams
   }
@@ -902,10 +902,10 @@ export class Script extends Artifact {
     const signerParams: SignExecuteScriptTxParams = {
       signerAddress: (await signer.getSelectedAccount()).address,
       bytecode: this.buildByteCodeToDeploy(params.initialFields ? params.initialFields : {}),
-      attoAlphAmount: extractOptionalNumber256(params.attoAlphAmount),
-      tokens: toApiTokens(params.tokens),
+      attoAlphAmount: params.attoAlphAmount,
+      tokens: params.tokens,
       gasAmount: params.gasAmount,
-      gasPrice: extractOptionalNumber256(params.gasPrice)
+      gasPrice: params.gasPrice
     }
     return signerParams
   }
@@ -921,10 +921,6 @@ export class Script extends Artifact {
   buildByteCodeToDeploy(initialFields: Fields): string {
     return ralph.buildScriptByteCode(this.bytecodeTemplate, initialFields, this.fieldsSig)
   }
-}
-
-function extractOptionalNumber256(v?: Val): string | undefined {
-  return typeof v !== 'undefined' ? toApiNumber256(v) : undefined
 }
 
 function fromApiFields(vals: node.Val[], fieldsSig: node.FieldsSig): Fields {
@@ -1102,7 +1098,7 @@ type BuildTxParams<T> = Omit<T, 'bytecode'> & { initialFields?: Val[] }
 export interface BuildDeployContractTx {
   signerAddress: string
   initialFields?: Fields
-  initialAttoAlphAmount?: string
+  initialAttoAlphAmount?: Number256
   initialTokenAmounts?: Token[]
   issueTokenAmount?: Number256
   gasAmount?: number

--- a/packages/web3/src/contract/contract.ts
+++ b/packages/web3/src/contract/contract.ts
@@ -32,7 +32,6 @@ import {
   toApiVal,
   Token,
   Val,
-  toApiTokens,
   fromApiTokens,
   fromApiVals
 } from '../api'

--- a/packages/web3/src/contract/ralph.test.ts
+++ b/packages/web3/src/contract/ralph.test.ts
@@ -130,7 +130,7 @@ describe('contract', function () {
   })
 
   it('should test buildScriptByteCode', async () => {
-    const variables = { x: true, y: 0x05, z: 'ff', a: '1C2RAVWSuaXw8xtUxqVERR7ChKBE1XgscNFw73NSHE1v3' }
+    const variables = { x: true, y: 0x05n, z: 'ff', a: '1C2RAVWSuaXw8xtUxqVERR7ChKBE1XgscNFw73NSHE1v3' }
     const fieldsSig: FieldsSig = {
       names: ['x', 'y', 'z', 'a'],
       types: ['Bool', 'U256', 'ByteVec', 'Address'],
@@ -142,8 +142,8 @@ describe('contract', function () {
 
   it('should test buildContractByteCode', async () => {
     const fields: Fields = {
-      a: -1,
-      b: 1,
+      a: -1n,
+      b: 1n,
       c: '23',
       d: '1C2RAVWSuaXw8xtUxqVERR7ChKBE1XgscNFw73NSHE1v3',
       e: [false, true]

--- a/packages/web3/src/signer/signer.ts
+++ b/packages/web3/src/signer/signer.ts
@@ -91,10 +91,10 @@ assertType<Eq<SignDeployContractTxResult, SignResult<node.BuildDeployContractTxR
 export interface SignExecuteScriptTxParams {
   signerAddress: string
   bytecode: string
-  attoAlphAmount?: string
+  attoAlphAmount?: Number256
   tokens?: Token[]
   gasAmount?: number
-  gasPrice?: string
+  gasPrice?: Number256
 }
 assertType<Eq<keyof SignExecuteScriptTxParams, keyof TxBuildParams<node.BuildExecuteScriptTx>>>()
 export interface SignExecuteScriptTxResult {
@@ -250,7 +250,9 @@ export abstract class SignerProviderSimple implements SignerProvider {
   async buildScriptTx(params: SignExecuteScriptTxParams): Promise<node.BuildExecuteScriptTxResult> {
     const data: node.BuildExecuteScriptTx = {
       ...(await this.usePublicKey(params)),
-      tokens: toApiTokens(params.tokens)
+      attoAlphAmount: toApiNumber256Optional(params.attoAlphAmount),
+      tokens: toApiTokens(params.tokens),
+      gasPrice: toApiNumber256Optional(params.gasPrice)
     }
     return this.getNodeProvider().contracts.postContractsUnsignedTxExecuteScript(data)
   }

--- a/test/contract.test.ts
+++ b/test/contract.test.ts
@@ -43,32 +43,32 @@ describe('contract', function () {
     const add = Project.contract('Add')
     const sub = Project.contract('Sub')
 
-    const subState = sub.toState({ result: 0 }, { alphAmount: BigInt('1000000000000000000') })
+    const subState = sub.toState({ result: 0n }, { alphAmount: BigInt('1000000000000000000') })
     const testParams: TestContractParams = {
-      initialFields: { sub: subState.contractId, result: 0 },
-      testArgs: { array: [2, 1] },
+      initialFields: { sub: subState.contractId, result: 0n },
+      testArgs: { array: [2n, 1n] },
       existingContracts: [subState]
     }
     const testResult = await add.testPublicMethod('add', testParams)
-    expect(testResult.returns).toEqual([[3, 1]])
+    expect(testResult.returns).toEqual([[3n, 1n]])
     expect(testResult.contracts[0].codeHash).toEqual(sub.codeHash)
-    expect(testResult.contracts[0].fields.result).toEqual(1)
+    expect(testResult.contracts[0].fields.result).toEqual(1n)
     expect(testResult.contracts[1].codeHash).toEqual(add.codeHash)
     expect(testResult.contracts[1].fields.sub).toEqual(subState.contractId)
-    expect(testResult.contracts[1].fields.result).toEqual(3)
+    expect(testResult.contracts[1].fields.result).toEqual(3n)
     const events = testResult.events.sort((a, b) => a.name.localeCompare(b.name))
     expect(events[0].name).toEqual('Add')
-    expect(events[0].fields.x).toEqual(2)
-    expect(events[0].fields.y).toEqual(1)
+    expect(events[0].fields.x).toEqual(2n)
+    expect(events[0].fields.y).toEqual(1n)
     expect(events[1].name).toEqual('Sub')
-    expect(events[1].fields.x).toEqual(2)
-    expect(events[1].fields.y).toEqual(1)
+    expect(events[1].fields.x).toEqual(2n)
+    expect(events[1].fields.y).toEqual(1n)
 
     const testResultPrivate = await add.testPrivateMethod('addPrivate', testParams)
-    expect(testResultPrivate.returns).toEqual([[3, 1]])
+    expect(testResultPrivate.returns).toEqual([[3n, 1n]])
 
     const subDeployTx = await sub.deploy(signer, {
-      initialFields: { result: 0 },
+      initialFields: { result: 0n },
       initialTokenAmounts: []
     })
     const subContractId = subDeployTx.contractId
@@ -80,7 +80,7 @@ describe('contract', function () {
     expect(subDeployTx.txId).toEqual(subDeployTx.txId)
 
     const addDeployTx = await add.deploy(signer, {
-      initialFields: { sub: subContractId, result: 0 },
+      initialFields: { sub: subContractId, result: 0n },
       initialTokenAmounts: []
     })
     expect(addDeployTx.fromGroup).toEqual(signerGroup)
@@ -94,10 +94,10 @@ describe('contract', function () {
 
     // Check state for add/sub before main script is executed
     let fetchedSubState = await sub.fetchState(subContractAddress, signerGroup)
-    expect(fetchedSubState.fields.result).toEqual(0)
+    expect(fetchedSubState.fields.result).toEqual(0n)
     let fetchedAddState = await add.fetchState(addContractAddress, signerGroup)
     expect(fetchedAddState.fields.sub).toEqual(subContractId)
-    expect(fetchedAddState.fields.result).toEqual(0)
+    expect(fetchedAddState.fields.result).toEqual(0n)
 
     const main = Project.script('Main')
     const mainScriptTx = await main.execute(signer, {
@@ -110,10 +110,10 @@ describe('contract', function () {
 
     // Check state for add/sub after main script is executed
     fetchedSubState = await sub.fetchState(subContractAddress, signerGroup)
-    expect(fetchedSubState.fields.result).toEqual(1)
+    expect(fetchedSubState.fields.result).toEqual(1n)
     fetchedAddState = await add.fetchState(addContractAddress, signerGroup)
     expect(fetchedAddState.fields.sub).toEqual(subContractId)
-    expect(fetchedAddState.fields.result).toEqual(3)
+    expect(fetchedAddState.fields.result).toEqual(3n)
   }
 
   async function testSuite2() {
@@ -122,15 +122,15 @@ describe('contract', function () {
     const greeter = Project.contract('Greeter')
 
     const testParams: TestContractParams = {
-      initialFields: { btcPrice: 1 }
+      initialFields: { btcPrice: 1n }
     }
     const testResult = await greeter.testPublicMethod('greet', testParams)
-    expect(testResult.returns).toEqual([1])
+    expect(testResult.returns).toEqual([1n])
     expect(testResult.contracts[0].codeHash).toEqual(greeter.codeHash)
-    expect(testResult.contracts[0].fields.btcPrice).toEqual(1)
+    expect(testResult.contracts[0].fields.btcPrice).toEqual(1n)
 
     const deployTx = await greeter.deploy(signer, {
-      initialFields: { btcPrice: 1 },
+      initialFields: { btcPrice: 1n },
       initialTokenAmounts: []
     })
     expect(deployTx.fromGroup).toEqual(signerGroup)

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -36,7 +36,7 @@ describe('events', function () {
   async function deployContract(signer: NodeWallet): Promise<[string, string]> {
     const sub = Project.contract('Sub')
     const subDeployTx = await sub.deploy(signer, {
-      initialFields: { result: 0 },
+      initialFields: { result: 0n },
       initialTokenAmounts: []
     })
     const subContractId = subDeployTx.contractId
@@ -44,7 +44,7 @@ describe('events', function () {
     // ignore unused private function warnings
     const add = Project.contract('Add')
     const addDeployTx = await add.deploy(signer, {
-      initialFields: { sub: subContractId, result: 0 },
+      initialFields: { sub: subContractId, result: 0n },
       initialTokenAmounts: []
     })
     return [addDeployTx.contractAddress, addDeployTx.contractId]

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -31,7 +31,7 @@ describe('transactions', function () {
     const sub = Project.contract('Sub')
     const signer = await testNodeWallet()
     const txParams = await sub.txParamsForDeployment(signer, {
-      initialFields: { result: 0 },
+      initialFields: { result: 0n },
       initialTokenAmounts: []
     })
     const subDeployTx = await signer.buildContractCreationTx(txParams)


### PR DESCRIPTION
To work better with JS/TS, this PR uses bigint for amounts. Reasons:
1. operations like `1n + 1` is not allowed in JS
2. the change will make the type of amount more predictable
3. no precision issues

There are some cons too:
1. No scientific notion support: 1e18n is invalid. The neat way I found so far is `10n ** 18n`.
2. A bit tedious to postfix `n` for amount literals. It's less of a problem because the compiler warns if a postfix is missing.

Similar design is made for `web3.js` as far as I have seen.