### PR TITLE
Fix isHexString

### DIFF
--- a/packages/web3/src/utils/utils.test.ts
+++ b/packages/web3/src/utils/utils.test.ts
@@ -165,4 +165,14 @@ describe('utils', function () {
     expect(utils.stringToHex('Hello Alephium!')).toBe('48656c6c6f20416c65706869756d21')
     expect(utils.hexToString('48656c6c6f20416c65706869756d21')).toBe('Hello Alephium!')
   })
+
+  it('should check hex string', () => {
+    expect(utils.isHexString('')).toBe(true)
+    expect(utils.isHexString('0011aaAAbbBBccCCddDDeeEEffFF')).toBe(true)
+
+    expect(utils.isHexString('0011aaAAbbBBccCCddDDeeEEffFFgg')).toBe(false)
+    expect(utils.isHexString('001')).toBe(false)
+    expect(utils.isHexString('0x1111')).toBe(false)
+    expect(utils.isHexString('1111xxzz')).toBe(false)
+  })
 })

--- a/packages/web3/src/utils/utils.ts
+++ b/packages/web3/src/utils/utils.ts
@@ -63,7 +63,7 @@ export function xorByte(intValue: number): number {
 }
 
 export function isHexString(input: string): boolean {
-  return input.length % 2 === 0 && /[0-9a-f]*$/.test(input)
+  return input.length % 2 === 0 && /^[0-9a-fA-F]*$/.test(input)
 }
 
 enum AddressType {


### PR DESCRIPTION
In the current implementation:

```
isHexString('0x11') is true
isHexString('xxzz') is true
```