### PR TITLE
Fix decode contract created system event

### DIFF
--- a/.project.json
+++ b/.project.json
@@ -10,9 +10,9 @@
   "infos": {
     "Add": {
       "sourceFile": "add/add.ral",
-      "sourceCodeHash": "afa13fb64cb9e0136d5e646a08ae0bcd45a6e02cd72a1f35a1603c3d9b738b19",
+      "sourceCodeHash": "fe564aa4ca11d1b597bb71935c2fab91a8c4ec35e4d4f509667b3f093bc9127b",
       "bytecodeDebugPatch": "",
-      "codeHashDebug": "52d5893e97ce6b8d67d90fe1c51735e6e4f9946de732926fd160a0b50774f61b",
+      "codeHashDebug": "8e495ae544b65cc598a162e7839540a9ba4c9bc33b03522afbd36c174489b629",
       "warnings": []
     },
     "Assert": {

--- a/artifacts/add/add.ral.json
+++ b/artifacts/add/add.ral.json
@@ -1,8 +1,8 @@
 {
   "version": "v1.7.0",
   "name": "Add",
-  "bytecode": "02020d40360100020402041600160100010200000202021605160016015f06160016015fa00016002a16012aa100a000160016010e0dce00010002",
-  "codeHash": "52d5893e97ce6b8d67d90fe1c51735e6e4f9946de732926fd160a0b50774f61b",
+  "bytecode": "02030d403640570100020402041600160100010200000202021605160016015f06160016015fa00016002a16012aa100a000160016010e0dce0001000201030404000b160313c40de0b6b3a7640000a2160116021401001600130164c118",
+  "codeHash": "8e495ae544b65cc598a162e7839540a9ba4c9bc33b03522afbd36c174489b629",
   "fieldsSig": {
     "names": [
       "sub",
@@ -77,6 +77,31 @@
       "returnTypes": [
         "[U256;2]"
       ]
+    },
+    {
+      "name": "createSubContract",
+      "usePreapprovedAssets": true,
+      "useAssetsInContract": false,
+      "isPublic": true,
+      "paramNames": [
+        "a",
+        "path",
+        "subContractId",
+        "payer"
+      ],
+      "paramTypes": [
+        "U256",
+        "ByteVec",
+        "ByteVec",
+        "Address"
+      ],
+      "paramIsMutable": [
+        false,
+        false,
+        false,
+        false
+      ],
+      "returnTypes": []
     }
   ]
 }

--- a/artifacts/ts/Add.ts
+++ b/artifacts/ts/Add.ts
@@ -57,6 +57,15 @@ class Factory extends ContractFactory<AddInstance, AddTypes.Fields> {
   ): Promise<TestContractResult<[bigint, bigint]>> {
     return testMethod(this, "addPrivate", params);
   }
+
+  async testCreateSubContractMethod(
+    params: TestContractParams<
+      AddTypes.Fields,
+      { a: bigint; path: HexString; subContractId: HexString; payer: HexString }
+    >
+  ): Promise<TestContractResult<null>> {
+    return testMethod(this, "createSubContract", params);
+  }
 }
 
 // Use this object to test and deploy the contract
@@ -64,7 +73,7 @@ export const Add = new Factory(
   Contract.fromJson(
     AddContractJson,
     "",
-    "52d5893e97ce6b8d67d90fe1c51735e6e4f9946de732926fd160a0b50774f61b"
+    "8e495ae544b65cc598a162e7839540a9ba4c9bc33b03522afbd36c174489b629"
   )
 );
 

--- a/contracts/add/add.ral
+++ b/contracts/add/add.ral
@@ -13,4 +13,9 @@ Contract Add(sub: Sub, mut result : U256) {
         result = result + array[0] + array[1]
         return [result, sub.sub(array)]
     }
+
+    @using(preapprovedAssets = true)
+    pub fn createSubContract(a: U256, path: ByteVec, subContractId: ByteVec, payer: Address) -> () {
+        copyCreateSubContract!{payer -> ALPH: 1 alph}(path, subContractId, #00, encodeToByteVec!(a))
+    }
 }

--- a/packages/cli/src/codegen.ts
+++ b/packages/cli/src/codegen.ts
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { node, Project, Script, Contract, EventSig } from '@alephium/web3'
+import { node, Project, Script, Contract, EventSig, SystemEventSig } from '@alephium/web3'
 import * as prettier from 'prettier'
 import path from 'path'
 import fs from 'fs'
@@ -206,7 +206,7 @@ function genTestMethod(contract: Contract, functionSig: node.FunctionSig): strin
 }
 
 type SystemEvent = {
-  eventSig: EventSig
+  eventSig: SystemEventSig
   eventIndex: number
   eventType: string
 }

--- a/packages/web3/src/api/types.ts
+++ b/packages/web3/src/api/types.ts
@@ -162,7 +162,13 @@ function _fromApiVal(vals: node.Val[], valIndex: number, tpe: string): [result: 
   }
 }
 
-export function fromApiVals(vals: node.Val[], names: string[], types: string[]): NamedVals {
+export function fromApiVals(
+  vals: node.Val[],
+  names: string[],
+  types: string[],
+  optionalNames: string[] = [],
+  optionalTypes: string[] = []
+): NamedVals {
   let valIndex = 0
   const result: NamedVals = {}
   types.forEach((currentType, index) => {
@@ -171,7 +177,11 @@ export function fromApiVals(vals: node.Val[], names: string[], types: string[]):
     valIndex = nextIndex
     result[`${currentName}`] = val
   })
-  return result
+  if (valIndex === vals.length) {
+    return result
+  }
+  const optionalFields = fromApiVals(vals.slice(valIndex), optionalNames, optionalTypes)
+  return { ...result, ...optionalFields }
 }
 
 export function fromApiArray(vals: node.Val[], types: string[]): Val[] {


### PR DESCRIPTION
In full node 1.7.0, the `ContractCreatedEvent` has an optional field `parentAddress`, this PR fix decodes `ContractCreatedEvent`.