### PR TITLE
Fix subscribe system events

### DIFF
--- a/.project.json
+++ b/.project.json
@@ -10,9 +10,9 @@
   "infos": {
     "Add": {
       "sourceFile": "add/add.ral",
-      "sourceCodeHash": "fe564aa4ca11d1b597bb71935c2fab91a8c4ec35e4d4f509667b3f093bc9127b",
+      "sourceCodeHash": "6d38a630a86ab41cf13b2a09988d13feedf1822873fc805dae67a58bdd872266",
       "bytecodeDebugPatch": "",
-      "codeHashDebug": "8e495ae544b65cc598a162e7839540a9ba4c9bc33b03522afbd36c174489b629",
+      "codeHashDebug": "2b9e382c20b4facf21eb745a46a72447dae221c274518e19c60b5ddfe478cc9c",
       "warnings": []
     },
     "Assert": {
@@ -27,6 +27,13 @@
       "sourceCodeHash": "0d7cdfad264cf2009dd8907b716ba0d79cc4cf722b35773129645c5415bcb4dc",
       "bytecodeDebugPatch": "=4-2+13=11+2ca7e=1+20748656c6c6f2c200121",
       "codeHashDebug": "0ffc72054e3668c8933e53c892947dea1963c0c24cc006a4fb0aa028c13a7e13",
+      "warnings": []
+    },
+    "DestroyAdd": {
+      "sourceFile": "add/destroy_add.ral",
+      "sourceCodeHash": "dbddae3cd53736478c299026ac67683909fcc04d036f98ce6dc72af7d92a4835",
+      "bytecodeDebugPatch": "",
+      "codeHashDebug": "",
       "warnings": []
     },
     "Greeter": {

--- a/artifacts/add/add.ral.json
+++ b/artifacts/add/add.ral.json
@@ -1,8 +1,8 @@
 {
   "version": "v1.7.1",
   "name": "Add",
-  "bytecode": "02030d403640570100020402041600160100010200000202021605160016015f06160016015fa00016002a16012aa100a000160016010e0dce0001000201030404000b160313c40de0b6b3a7640000a2160116021401001600130164c118",
-  "codeHash": "8e495ae544b65cc598a162e7839540a9ba4c9bc33b03522afbd36c174489b629",
+  "bytecode": "02040d4036405740600100020402041600160100010200000202021605160016015f06160016015fa00016002a16012aa100a000160016010e0dce0001000201030404000b160313c40de0b6b3a7640000a2160116021401001600130164c1180102010100021600b0",
+  "codeHash": "2b9e382c20b4facf21eb745a46a72447dae221c274518e19c60b5ddfe478cc9c",
   "fieldsSig": {
     "names": [
       "sub",
@@ -99,6 +99,22 @@
         false,
         false,
         false,
+        false
+      ],
+      "returnTypes": []
+    },
+    {
+      "name": "destroy",
+      "usePreapprovedAssets": false,
+      "useAssetsInContract": true,
+      "isPublic": true,
+      "paramNames": [
+        "caller"
+      ],
+      "paramTypes": [
+        "Address"
+      ],
+      "paramIsMutable": [
         false
       ],
       "returnTypes": []

--- a/artifacts/add/destroy_add.ral.json
+++ b/artifacts/add/destroy_add.ral.json
@@ -1,0 +1,31 @@
+{
+  "version": "v1.7.1",
+  "name": "DestroyAdd",
+  "bytecodeTemplate": "01010300000005{1}0d0c{0}0103",
+  "fieldsSig": {
+    "names": [
+      "add",
+      "caller"
+    ],
+    "types": [
+      "ByteVec",
+      "Address"
+    ],
+    "isMutable": [
+      false,
+      false
+    ]
+  },
+  "functions": [
+    {
+      "name": "main",
+      "usePreapprovedAssets": true,
+      "useAssetsInContract": false,
+      "isPublic": true,
+      "paramNames": [],
+      "paramTypes": [],
+      "paramIsMutable": [],
+      "returnTypes": []
+    }
+  ]
+}

--- a/artifacts/ts/Add.ts
+++ b/artifacts/ts/Add.ts
@@ -62,6 +62,12 @@ class Factory extends ContractFactory<AddInstance, AddTypes.Fields> {
   ): Promise<TestContractResult<null>> {
     return testMethod(this, "createSubContract", params);
   }
+
+  async testDestroyMethod(
+    params: TestContractParams<AddTypes.Fields, { caller: HexString }>
+  ): Promise<TestContractResult<null>> {
+    return testMethod(this, "destroy", params);
+  }
 }
 
 // Use this object to test and deploy the contract
@@ -69,7 +75,7 @@ export const Add = new Factory(
   Contract.fromJson(
     AddContractJson,
     "",
-    "8e495ae544b65cc598a162e7839540a9ba4c9bc33b03522afbd36c174489b629"
+    "2b9e382c20b4facf21eb745a46a72447dae221c274518e19c60b5ddfe478cc9c"
   )
 );
 

--- a/artifacts/ts/Add.ts
+++ b/artifacts/ts/Add.ts
@@ -15,15 +15,11 @@ import {
   CallContractResult,
   TestContractParams,
   ContractEvent,
-  subscribeContractCreatedEvent,
-  subscribeContractDestroyedEvent,
   subscribeContractEvent,
-  subscribeAllEvents,
+  subscribeContractEvents,
   testMethod,
   callMethod,
   fetchContractState,
-  ContractCreatedEvent,
-  ContractDestroyedEvent,
   ContractInstance,
 } from "@alephium/web3";
 import { default as AddContractJson } from "../add/add.ral.json";
@@ -87,20 +83,6 @@ export class AddInstance extends ContractInstance {
     return fetchContractState(Add, this);
   }
 
-  subscribeContractCreatedEvent(
-    options: SubscribeOptions<ContractCreatedEvent>,
-    fromCount?: number
-  ): EventSubscription {
-    return subscribeContractCreatedEvent(this, options, fromCount);
-  }
-
-  subscribeContractDestroyedEvent(
-    options: SubscribeOptions<ContractDestroyedEvent>,
-    fromCount?: number
-  ): EventSubscription {
-    return subscribeContractDestroyedEvent(this, options, fromCount);
-  }
-
   subscribeAddEvent(
     options: SubscribeOptions<AddTypes.AddEvent>,
     fromCount?: number
@@ -128,15 +110,10 @@ export class AddInstance extends ContractInstance {
   }
 
   subscribeAllEvents(
-    options: SubscribeOptions<
-      | AddTypes.AddEvent
-      | AddTypes.Add1Event
-      | ContractCreatedEvent
-      | ContractDestroyedEvent
-    >,
+    options: SubscribeOptions<AddTypes.AddEvent | AddTypes.Add1Event>,
     fromCount?: number
   ): EventSubscription {
-    return subscribeAllEvents(Add.contract, this, options, fromCount);
+    return subscribeContractEvents(Add.contract, this, options, fromCount);
   }
 
   async callAddMethod(

--- a/artifacts/ts/Assert.ts
+++ b/artifacts/ts/Assert.ts
@@ -15,15 +15,11 @@ import {
   CallContractResult,
   TestContractParams,
   ContractEvent,
-  subscribeContractCreatedEvent,
-  subscribeContractDestroyedEvent,
   subscribeContractEvent,
-  subscribeAllEvents,
+  subscribeContractEvents,
   testMethod,
   callMethod,
   fetchContractState,
-  ContractCreatedEvent,
-  ContractDestroyedEvent,
   ContractInstance,
 } from "@alephium/web3";
 import { default as AssertContractJson } from "../test/assert.ral.json";
@@ -65,26 +61,5 @@ export class AssertInstance extends ContractInstance {
 
   async fetchState(): Promise<AssertTypes.State> {
     return fetchContractState(Assert, this);
-  }
-
-  subscribeContractCreatedEvent(
-    options: SubscribeOptions<ContractCreatedEvent>,
-    fromCount?: number
-  ): EventSubscription {
-    return subscribeContractCreatedEvent(this, options, fromCount);
-  }
-
-  subscribeContractDestroyedEvent(
-    options: SubscribeOptions<ContractDestroyedEvent>,
-    fromCount?: number
-  ): EventSubscription {
-    return subscribeContractDestroyedEvent(this, options, fromCount);
-  }
-
-  subscribeAllEvents(
-    options: SubscribeOptions<ContractCreatedEvent | ContractDestroyedEvent>,
-    fromCount?: number
-  ): EventSubscription {
-    return subscribeAllEvents(Assert.contract, this, options, fromCount);
   }
 }

--- a/artifacts/ts/Debug.ts
+++ b/artifacts/ts/Debug.ts
@@ -15,15 +15,11 @@ import {
   CallContractResult,
   TestContractParams,
   ContractEvent,
-  subscribeContractCreatedEvent,
-  subscribeContractDestroyedEvent,
   subscribeContractEvent,
-  subscribeAllEvents,
+  subscribeContractEvents,
   testMethod,
   callMethod,
   fetchContractState,
-  ContractCreatedEvent,
-  ContractDestroyedEvent,
   ContractInstance,
 } from "@alephium/web3";
 import { default as DebugContractJson } from "../test/debug.ral.json";
@@ -65,26 +61,5 @@ export class DebugInstance extends ContractInstance {
 
   async fetchState(): Promise<DebugTypes.State> {
     return fetchContractState(Debug, this);
-  }
-
-  subscribeContractCreatedEvent(
-    options: SubscribeOptions<ContractCreatedEvent>,
-    fromCount?: number
-  ): EventSubscription {
-    return subscribeContractCreatedEvent(this, options, fromCount);
-  }
-
-  subscribeContractDestroyedEvent(
-    options: SubscribeOptions<ContractDestroyedEvent>,
-    fromCount?: number
-  ): EventSubscription {
-    return subscribeContractDestroyedEvent(this, options, fromCount);
-  }
-
-  subscribeAllEvents(
-    options: SubscribeOptions<ContractCreatedEvent | ContractDestroyedEvent>,
-    fromCount?: number
-  ): EventSubscription {
-    return subscribeAllEvents(Debug.contract, this, options, fromCount);
   }
 }

--- a/artifacts/ts/Greeter.ts
+++ b/artifacts/ts/Greeter.ts
@@ -15,15 +15,11 @@ import {
   CallContractResult,
   TestContractParams,
   ContractEvent,
-  subscribeContractCreatedEvent,
-  subscribeContractDestroyedEvent,
   subscribeContractEvent,
-  subscribeAllEvents,
+  subscribeContractEvents,
   testMethod,
   callMethod,
   fetchContractState,
-  ContractCreatedEvent,
-  ContractDestroyedEvent,
   ContractInstance,
 } from "@alephium/web3";
 import { default as GreeterContractJson } from "../greeter/greeter.ral.json";
@@ -66,27 +62,6 @@ export class GreeterInstance extends ContractInstance {
 
   async fetchState(): Promise<GreeterTypes.State> {
     return fetchContractState(Greeter, this);
-  }
-
-  subscribeContractCreatedEvent(
-    options: SubscribeOptions<ContractCreatedEvent>,
-    fromCount?: number
-  ): EventSubscription {
-    return subscribeContractCreatedEvent(this, options, fromCount);
-  }
-
-  subscribeContractDestroyedEvent(
-    options: SubscribeOptions<ContractDestroyedEvent>,
-    fromCount?: number
-  ): EventSubscription {
-    return subscribeContractDestroyedEvent(this, options, fromCount);
-  }
-
-  subscribeAllEvents(
-    options: SubscribeOptions<ContractCreatedEvent | ContractDestroyedEvent>,
-    fromCount?: number
-  ): EventSubscription {
-    return subscribeAllEvents(Greeter.contract, this, options, fromCount);
   }
 
   async callGreetMethod(

--- a/artifacts/ts/MetaData.ts
+++ b/artifacts/ts/MetaData.ts
@@ -15,15 +15,11 @@ import {
   CallContractResult,
   TestContractParams,
   ContractEvent,
-  subscribeContractCreatedEvent,
-  subscribeContractDestroyedEvent,
   subscribeContractEvent,
-  subscribeAllEvents,
+  subscribeContractEvents,
   testMethod,
   callMethod,
   fetchContractState,
-  ContractCreatedEvent,
-  ContractDestroyedEvent,
   ContractInstance,
 } from "@alephium/web3";
 import { default as MetaDataContractJson } from "../test/metadata.ral.json";
@@ -83,26 +79,5 @@ export class MetaDataInstance extends ContractInstance {
 
   async fetchState(): Promise<MetaDataTypes.State> {
     return fetchContractState(MetaData, this);
-  }
-
-  subscribeContractCreatedEvent(
-    options: SubscribeOptions<ContractCreatedEvent>,
-    fromCount?: number
-  ): EventSubscription {
-    return subscribeContractCreatedEvent(this, options, fromCount);
-  }
-
-  subscribeContractDestroyedEvent(
-    options: SubscribeOptions<ContractDestroyedEvent>,
-    fromCount?: number
-  ): EventSubscription {
-    return subscribeContractDestroyedEvent(this, options, fromCount);
-  }
-
-  subscribeAllEvents(
-    options: SubscribeOptions<ContractCreatedEvent | ContractDestroyedEvent>,
-    fromCount?: number
-  ): EventSubscription {
-    return subscribeAllEvents(MetaData.contract, this, options, fromCount);
   }
 }

--- a/artifacts/ts/Sub.ts
+++ b/artifacts/ts/Sub.ts
@@ -15,15 +15,11 @@ import {
   CallContractResult,
   TestContractParams,
   ContractEvent,
-  subscribeContractCreatedEvent,
-  subscribeContractDestroyedEvent,
   subscribeContractEvent,
-  subscribeAllEvents,
+  subscribeContractEvents,
   testMethod,
   callMethod,
   fetchContractState,
-  ContractCreatedEvent,
-  ContractDestroyedEvent,
   ContractInstance,
 } from "@alephium/web3";
 import { default as SubContractJson } from "../sub/sub.ral.json";
@@ -70,20 +66,6 @@ export class SubInstance extends ContractInstance {
     return fetchContractState(Sub, this);
   }
 
-  subscribeContractCreatedEvent(
-    options: SubscribeOptions<ContractCreatedEvent>,
-    fromCount?: number
-  ): EventSubscription {
-    return subscribeContractCreatedEvent(this, options, fromCount);
-  }
-
-  subscribeContractDestroyedEvent(
-    options: SubscribeOptions<ContractDestroyedEvent>,
-    fromCount?: number
-  ): EventSubscription {
-    return subscribeContractDestroyedEvent(this, options, fromCount);
-  }
-
   subscribeSubEvent(
     options: SubscribeOptions<SubTypes.SubEvent>,
     fromCount?: number
@@ -95,15 +77,6 @@ export class SubInstance extends ContractInstance {
       "Sub",
       fromCount
     );
-  }
-
-  subscribeAllEvents(
-    options: SubscribeOptions<
-      SubTypes.SubEvent | ContractCreatedEvent | ContractDestroyedEvent
-    >,
-    fromCount?: number
-  ): EventSubscription {
-    return subscribeAllEvents(Sub.contract, this, options, fromCount);
   }
 
   async callSubMethod(

--- a/artifacts/ts/TokenTest.ts
+++ b/artifacts/ts/TokenTest.ts
@@ -15,15 +15,11 @@ import {
   CallContractResult,
   TestContractParams,
   ContractEvent,
-  subscribeContractCreatedEvent,
-  subscribeContractDestroyedEvent,
   subscribeContractEvent,
-  subscribeAllEvents,
+  subscribeContractEvents,
   testMethod,
   callMethod,
   fetchContractState,
-  ContractCreatedEvent,
-  ContractDestroyedEvent,
   ContractInstance,
 } from "@alephium/web3";
 import { default as TokenTestContractJson } from "../token_test.ral.json";
@@ -90,27 +86,6 @@ export class TokenTestInstance extends ContractInstance {
 
   async fetchState(): Promise<TokenTestTypes.State> {
     return fetchContractState(TokenTest, this);
-  }
-
-  subscribeContractCreatedEvent(
-    options: SubscribeOptions<ContractCreatedEvent>,
-    fromCount?: number
-  ): EventSubscription {
-    return subscribeContractCreatedEvent(this, options, fromCount);
-  }
-
-  subscribeContractDestroyedEvent(
-    options: SubscribeOptions<ContractDestroyedEvent>,
-    fromCount?: number
-  ): EventSubscription {
-    return subscribeContractDestroyedEvent(this, options, fromCount);
-  }
-
-  subscribeAllEvents(
-    options: SubscribeOptions<ContractCreatedEvent | ContractDestroyedEvent>,
-    fromCount?: number
-  ): EventSubscription {
-    return subscribeAllEvents(TokenTest.contract, this, options, fromCount);
   }
 
   async callGetSymbolMethod(

--- a/artifacts/ts/Warnings.ts
+++ b/artifacts/ts/Warnings.ts
@@ -15,15 +15,11 @@ import {
   CallContractResult,
   TestContractParams,
   ContractEvent,
-  subscribeContractCreatedEvent,
-  subscribeContractDestroyedEvent,
   subscribeContractEvent,
-  subscribeAllEvents,
+  subscribeContractEvents,
   testMethod,
   callMethod,
   fetchContractState,
-  ContractCreatedEvent,
-  ContractDestroyedEvent,
   ContractInstance,
 } from "@alephium/web3";
 import { default as WarningsContractJson } from "../test/warnings.ral.json";
@@ -67,26 +63,5 @@ export class WarningsInstance extends ContractInstance {
 
   async fetchState(): Promise<WarningsTypes.State> {
     return fetchContractState(Warnings, this);
-  }
-
-  subscribeContractCreatedEvent(
-    options: SubscribeOptions<ContractCreatedEvent>,
-    fromCount?: number
-  ): EventSubscription {
-    return subscribeContractCreatedEvent(this, options, fromCount);
-  }
-
-  subscribeContractDestroyedEvent(
-    options: SubscribeOptions<ContractDestroyedEvent>,
-    fromCount?: number
-  ): EventSubscription {
-    return subscribeContractDestroyedEvent(this, options, fromCount);
-  }
-
-  subscribeAllEvents(
-    options: SubscribeOptions<ContractCreatedEvent | ContractDestroyedEvent>,
-    fromCount?: number
-  ): EventSubscription {
-    return subscribeAllEvents(Warnings.contract, this, options, fromCount);
   }
 }

--- a/artifacts/ts/scripts.ts
+++ b/artifacts/ts/scripts.ts
@@ -9,8 +9,21 @@ import {
   SignerProvider,
   HexString,
 } from "@alephium/web3";
+import { default as DestroyAddScriptJson } from "../add/destroy_add.ral.json";
 import { default as GreeterMainScriptJson } from "../greeter_main.ral.json";
 import { default as MainScriptJson } from "../main.ral.json";
+
+export namespace DestroyAdd {
+  export async function execute(
+    signer: SignerProvider,
+    params: ExecuteScriptParams<{ add: HexString; caller: HexString }>
+  ): Promise<ExecuteScriptResult> {
+    const signerParams = await script.txParamsForExecution(signer, params);
+    return await signer.signAndSubmitExecuteScriptTx(signerParams);
+  }
+
+  export const script = Script.fromJson(DestroyAddScriptJson);
+}
 
 export namespace GreeterMain {
   export async function execute(

--- a/contracts/add/add.ral
+++ b/contracts/add/add.ral
@@ -18,4 +18,9 @@ Contract Add(sub: Sub, mut result : U256) {
     pub fn createSubContract(a: U256, path: ByteVec, subContractId: ByteVec, payer: Address) -> () {
         copyCreateSubContract!{payer -> ALPH: 1 alph}(path, subContractId, #00, encodeToByteVec!(a))
     }
+
+    @using(checkExternalCaller = false, assetsInContract = true)
+    pub fn destroy(caller: Address) -> () {
+        destroySelf!(caller)
+    }
 }

--- a/contracts/add/destroy_add.ral
+++ b/contracts/add/destroy_add.ral
@@ -1,0 +1,3 @@
+TxScript DestroyAdd(add: Add, caller: Address) {
+  add.destroy(caller)
+}

--- a/test/contract.test.ts
+++ b/test/contract.test.ts
@@ -208,10 +208,10 @@ describe('contract', function () {
 
   it('should load source files by order', async () => {
     const sourceFiles = await Project['loadSourceFiles']('.', './contracts') // `loadSourceFiles` is a private method
-    expect(sourceFiles.length).toEqual(12)
+    expect(sourceFiles.length).toEqual(13)
     sourceFiles.slice(0, 8).forEach((c) => expect(c.type).toEqual(0)) // contracts
-    sourceFiles.slice(9, 10).forEach((s) => expect(s.type).toEqual(1)) // scripts
-    sourceFiles.slice(11).forEach((i) => expect(i.type).toEqual(3)) // interfaces
+    sourceFiles.slice(9, 11).forEach((s) => expect(s.type).toEqual(1)) // scripts
+    sourceFiles.slice(12).forEach((i) => expect(i.type).toEqual(3)) // interfaces
   })
 
   it('should load contract from json', () => {

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { ContractCreatedEvent, ContractDestroyedEvent, Project } from '../packages/web3'
+import { Project } from '../packages/web3'
 import { NodeWallet } from '../packages/web3-wallet'
 import { SubscribeOptions, timeout } from '../packages/web3'
 import { web3 } from '../packages/web3'
@@ -73,7 +73,7 @@ describe('events', function () {
 
   it('should subscribe all events', async () => {
     const add = await deployContract(signer)
-    type EventTypes = AddTypes.AddEvent | AddTypes.Add1Event | ContractCreatedEvent | ContractDestroyedEvent
+    type EventTypes = AddTypes.AddEvent | AddTypes.Add1Event
     const addEvents: Array<EventTypes> = []
     const subscriptOptions: SubscribeOptions<EventTypes> = {
       pollingInterval: 500,


### PR DESCRIPTION
We use special contract addresses for system events, we don't need to generate subscribe system events code for contract instances.