### PR TITLE
Fix private key to hex string

### DIFF
--- a/packages/web3-wallet/src/privatekey-wallet.ts
+++ b/packages/web3-wallet/src/privatekey-wallet.ts
@@ -61,7 +61,7 @@ export class PrivateKeyWallet extends SignerProviderSimple {
 
   static Random(targetGroup?: number, nodeProvider?: NodeProvider, keyType?: KeyType): PrivateKeyWallet {
     const keyPair = ec.genKeyPair()
-    const wallet = new PrivateKeyWallet(keyPair.getPrivate().toString('hex'), keyType, nodeProvider)
+    const wallet = new PrivateKeyWallet(keyPair.getPrivate().toString('hex', 64), keyType, nodeProvider)
     if (targetGroup === undefined || wallet.group === targetGroup) {
       return wallet
     } else {

--- a/packages/web3/src/utils/sign.test.ts
+++ b/packages/web3/src/utils/sign.test.ts
@@ -36,7 +36,7 @@ describe('Signing', function () {
   it('should sign and verify schnorr signature', () => {
     const ec = new EC.ec('secp256k1')
     const key = ec.genKeyPair()
-    const privateKey = key.getPrivate().toString('hex')
+    const privateKey = key.getPrivate().toString('hex', 64)
     const publicKey = publicKeyFromPrivateKey(privateKey, 'bip340-schnorr')
 
     const hash = '8fc5f0d120b730f97f6cea5f02ae4a6ee7bf451d9261c623ea69d85e870201d2'


### PR DESCRIPTION
This test sometimes fails:

```
 FAIL  src/utils/sign.test.ts
  ● Signing › should sign and verify schnorr signature

    Expected 32 bytes of private key

      46 |     return encodeSignature(signature)
      47 |   } else {
    > 48 |     const signature = necc.schnorr.signSync(hexToBinUnsafe(hash), hexToBinUnsafe(privateKey))
         |                                    ^
      49 |     return binToHex(signature)
      50 |   }
      51 | }

      at normalizePrivateKey (../../node_modules/@noble/secp256k1/lib/index.js:807:19)
      at new InternalSchnorrSignature (../../node_modules/@noble/secp256k1/lib/index.js:993:46)
      at Object.schnorrSignSync [as signSync] (../../node_modules/@noble/secp256k1/lib/index.js:1048:12)
      at signSync (src/utils/sign.ts:48:36)
      at Object.<anonymous> (src/utils/sign.test.ts:43:27)
```