### PR TITLE
Improve deployments schema

### DIFF
--- a/packages/cli/src/deployment.ts
+++ b/packages/cli/src/deployment.ts
@@ -73,11 +73,11 @@ export class Deployments {
   }
 
   getDeployedContractResult(group: number, name: string): DeployContractExecutionResult | undefined {
-    return this.deploymentsByGroup(group)?.deployContractResults.get(name)
+    return this.deploymentsByGroup(group)?.contracts.get(name)
   }
 
   getExecutedScriptResult(group: number, name: string): RunScriptResult | undefined {
-    return this.deploymentsByGroup(group)?.runScriptResults.get(name)
+    return this.deploymentsByGroup(group)?.scripts.get(name)
   }
 
   async saveToFile(filepath: string): Promise<void> {
@@ -115,17 +115,17 @@ export class Deployments {
 }
 
 export class DeploymentsPerGroup {
-  deployContractResults: Map<string, DeployContractExecutionResult>
-  runScriptResults: Map<string, RunScriptResult>
+  contracts: Map<string, DeployContractExecutionResult>
+  scripts: Map<string, RunScriptResult>
   migrations: Map<string, number>
 
   constructor(
-    deployContractResults: Map<string, DeployContractExecutionResult>,
-    runScriptResults: Map<string, RunScriptResult>,
+    contracts: Map<string, DeployContractExecutionResult>,
+    scripts: Map<string, RunScriptResult>,
     migrations: Map<string, number>
   ) {
-    this.deployContractResults = deployContractResults
-    this.runScriptResults = runScriptResults
+    this.contracts = contracts
+    this.scripts = scripts
     this.migrations = migrations
   }
 
@@ -135,17 +135,17 @@ export class DeploymentsPerGroup {
 
   marshal(): any {
     return {
-      deployContractResults: Object.fromEntries(this.deployContractResults),
-      runScriptResults: Object.fromEntries(this.runScriptResults),
+      contracts: Object.fromEntries(this.contracts),
+      scripts: Object.fromEntries(this.scripts),
       migrations: Object.fromEntries(this.migrations)
     }
   }
 
   static unmarshal(json: any): DeploymentsPerGroup {
-    const deployContractResults = new Map(Object.entries<DeployContractExecutionResult>(json.deployContractResults))
-    const runScriptResults = new Map(Object.entries<RunScriptResult>(json.runScriptResults))
+    const contracts = new Map(Object.entries<DeployContractExecutionResult>(json.contracts))
+    const scripts = new Map(Object.entries<RunScriptResult>(json.scripts))
     const migrations = new Map(Object.entries<number>(json.migrations))
-    return new DeploymentsPerGroup(deployContractResults, runScriptResults, migrations)
+    return new DeploymentsPerGroup(contracts, scripts, migrations)
   }
 }
 
@@ -477,7 +477,7 @@ async function deployToGroup<Settings = unknown>(
   network: Network<Settings>,
   scripts: { scriptFilePath: string; func: DeployFunction<Settings> }[]
 ) {
-  const deployer = createDeployer(network, signer, deployments.deployContractResults, deployments.runScriptResults)
+  const deployer = createDeployer(network, signer, deployments.contracts, deployments.scripts)
 
   for (const script of scripts) {
     try {

--- a/packages/cli/src/deployment.ts
+++ b/packages/cli/src/deployment.ts
@@ -116,6 +116,19 @@ export class Deployments {
   }
 }
 
+export async function getDeploymentResult(filepath: string): Promise<DeploymentsPerGroup> {
+  const deployments = await Deployments.from(filepath)
+  if (deployments.groups.size > 1) {
+    throw new Error('The contracts has been deployed to multiple groups')
+  }
+  return Array.from(deployments.groups.values())[0]
+}
+
+export async function getDeploymentResults(filepath: string): Promise<DeploymentsPerGroup[]> {
+  const deployments = await Deployments.from(filepath)
+  return Array.from(deployments.groups.values())
+}
+
 export class DeploymentsPerGroup {
   deployerAddress: string
   contracts: Map<string, DeployContractExecutionResult>

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -29,7 +29,6 @@ import {
   web3,
   Project,
   DEFAULT_COMPILER_OPTIONS,
-  Number256,
   SignerProvider,
   Script
 } from '@alephium/web3'
@@ -111,17 +110,17 @@ export interface ExecutionResult {
   unsignedTx: string
   signature: string
   gasAmount: number
-  gasPrice: Number256
+  gasPrice: string
   blockHash: string
   codeHash: string
-  attoAlphAmount?: Number256
+  attoAlphAmount?: string
   tokens?: Record<string, string>
 }
 
 export interface DeployContractExecutionResult extends ExecutionResult {
   contractId: string
   contractAddress: string
-  issueTokenAmount?: Number256
+  issueTokenAmount?: string
 }
 
 export type RunScriptResult = ExecutionResult

--- a/packages/cli/templates/base/src/token.ts
+++ b/packages/cli/templates/base/src/token.ts
@@ -1,5 +1,5 @@
 import { Deployments } from '@alephium/cli'
-import { web3, Project, stringifyJsonWithBigint } from '@alephium/web3'
+import { web3, Project } from '@alephium/web3'
 import { testNodeWallet } from '@alephium/web3-test'
 import configuration from '../alephium.config'
 import { TokenFaucet, Withdraw } from '../artifacts/ts'

--- a/packages/cli/templates/base/test/token.test.ts
+++ b/packages/cli/templates/base/test/token.test.ts
@@ -11,7 +11,7 @@ describe('unit tests', () => {
 
   // We initialize the fixture variables before all tests
   beforeAll(async () => {
-    web3.setCurrentNodeProvider('http://127.0.0.1:22973')
+    web3.setCurrentNodeProvider('http://127.0.0.1:22973', undefined, fetch)
     await Project.build()
     testContractId = randomContractId()
     testTokenId = testContractId
@@ -103,7 +103,7 @@ describe('unit tests', () => {
 
 describe('integration tests', () => {
   beforeAll(async () => {
-    web3.setCurrentNodeProvider('http://127.0.0.1:22973')
+    web3.setCurrentNodeProvider('http://127.0.0.1:22973', undefined, fetch)
     await Project.build()
   })
 


### PR DESCRIPTION
Since we reverted the parse `bigint` in [this PR](https://github.com/alephium/alephium-web3/pull/121), I changed the `Number256` type in the deployments schema to `string` so we don't need to deal with `bigint` specifically.