### PR TITLE
Bump core @alephium packages to latest version in templates

### DIFF
--- a/packages/cli/templates/base/package.json
+++ b/packages/cli/templates/base/package.json
@@ -15,10 +15,10 @@
     "test": "jest -i --config ./jest-config.json"
   },
   "dependencies": {
-    "@alephium/cli": "0.5.4",
-    "@alephium/web3": "0.5.4",
-    "@alephium/web3-test": "0.5.4",
-    "@alephium/web3-wallet": "0.5.4"
+    "@alephium/cli": "0.6.5",
+    "@alephium/web3": "0.6.5",
+    "@alephium/web3-test": "0.6.5",
+    "@alephium/web3-wallet": "0.6.5"
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",

--- a/packages/cli/templates/react/package.json
+++ b/packages/cli/templates/react/package.json
@@ -9,7 +9,7 @@
     "@types/node": "^16.11.26",
     "@types/react": "^18.0.3",
     "@types/react-dom": "^18.0.0",
-    "@alephium/web3": "0.5.4",
+    "@alephium/web3": "0.6.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-scripts": "5.0.1",


### PR DESCRIPTION
Ran into issues following the [getting started guide](https://docs.alephium.org/dapps/getting-started/) on windows, after some digging it appears everything is already fixed in latest versions including the import path thing [someone mentioned on discord yesterday](https://discord.com/channels/747741246667227157/948144672402972682/1083502450780143696) appears to be fixed by https://github.com/alephium/alephium-web3/commit/e80e545e81ee1a69ae22c7e2761ec31d436fa24a.

The getting started guide appears to work end to end now on windows + powershell