### PR TITLE
Fix circular imports

### DIFF
--- a/packages/web3-react/src/components/AlephiumConnect.tsx
+++ b/packages/web3-react/src/components/AlephiumConnect.tsx
@@ -15,7 +15,7 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
-import React, { createContext, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import defaultTheme from '../styles/defaultTheme'
 
@@ -23,47 +23,12 @@ import AlephiumConnectModal from '../components/ConnectModal'
 import { ThemeProvider } from 'styled-components'
 import { Account, KeyType, SignerProvider } from '@alephium/web3'
 import { Theme, Mode, CustomTheme } from '../types'
-
-export const routes = {
-  CONNECTORS: 'CONNECTORS',
-  PROFILE: 'PROFILE',
-  CONNECT: 'CONNECT'
-}
-
-type Connector = any
-type Error = string | React.ReactNode | null
-
-type ContextValue = {
-  open: boolean
-  setOpen: React.Dispatch<React.SetStateAction<boolean>>
-  route: string
-  setRoute: React.Dispatch<React.SetStateAction<string>>
-  errorMessage: Error
-  connector: Connector
-  setConnector: React.Dispatch<React.SetStateAction<Connector>>
-  account?: Account
-  setAccount: React.Dispatch<React.SetStateAction<Account | undefined>>
-  displayAccount?: (account: Account) => string
-  signerProvider?: SignerProvider
-  setSignerProvider: React.Dispatch<React.SetStateAction<SignerProvider | undefined>>
-  addressGroup?: number
-  keyType?: KeyType
-  network?: string
-  theme: Theme
-  setTheme: React.Dispatch<React.SetStateAction<Theme>>
-  mode: Mode
-  setMode: React.Dispatch<React.SetStateAction<Mode>>
-  customTheme: CustomTheme
-  setCustomTheme: React.Dispatch<React.SetStateAction<CustomTheme>>
-}
-
-const Context = createContext<ContextValue | null>(null)
-
-export const useContext = () => {
-  const context = React.useContext(Context)
-  if (!context) throw Error('AlephiumConnect Hook must be inside a Provider.')
-  return context
-}
+import { routes } from './Common/Modal'
+import {
+  AlephiumConnectContext,
+  AlephiumConnectContextValue,
+  useAlephiumConnectContext
+} from '../contexts/alephiumConnect'
 
 type AlephiumConnectProviderProps = {
   useTheme?: Theme
@@ -86,7 +51,8 @@ export const AlephiumConnectProvider: React.FC<AlephiumConnectProviderProps> = (
 }) => {
   // Only allow for mounting AlephiumConnectProvider once, so we avoid weird global
   // state collisions.
-  if (React.useContext(Context)) {
+  const context = useAlephiumConnectContext()
+  if (context) {
     throw new Error('Multiple, nested usages of AlephiumConnectProvider detected. Please use only one.')
   }
 
@@ -98,7 +64,7 @@ export const AlephiumConnectProvider: React.FC<AlephiumConnectProviderProps> = (
   const [connector, setConnector] = useState<string>('')
   const [route, setRoute] = useState<string>(routes.CONNECTORS)
   const [account, setAccount] = useState<Account>()
-  const [errorMessage, setErrorMessage] = useState<Error>('')
+  const [errorMessage, setErrorMessage] = useState<AlephiumConnectContextValue['errorMessage']>('')
   const [signerProvider, setSignerProvider] = useState<SignerProvider | undefined>()
 
   useEffect(() => setTheme(theme), [theme])
@@ -130,11 +96,11 @@ export const AlephiumConnectProvider: React.FC<AlephiumConnectProviderProps> = (
   }
 
   return (
-    <Context.Provider value={value}>
+    <AlephiumConnectContext.Provider value={value}>
       <ThemeProvider theme={defaultTheme}>
         {children}
         <AlephiumConnectModal theme={theme} mode={mode} customTheme={customTheme} />
       </ThemeProvider>
-    </Context.Provider>
+    </AlephiumConnectContext.Provider>
   )
 }

--- a/packages/web3-react/src/components/AlephiumConnect.tsx
+++ b/packages/web3-react/src/components/AlephiumConnect.tsx
@@ -15,7 +15,7 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
-import React, { useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 
 import defaultTheme from '../styles/defaultTheme'
 
@@ -24,11 +24,7 @@ import { ThemeProvider } from 'styled-components'
 import { Account, KeyType, SignerProvider } from '@alephium/web3'
 import { Theme, Mode, CustomTheme } from '../types'
 import { routes } from './Common/Modal'
-import {
-  AlephiumConnectContext,
-  AlephiumConnectContextValue,
-  useAlephiumConnectContext
-} from '../contexts/alephiumConnect'
+import { AlephiumConnectContext, AlephiumConnectContextValue } from '../contexts/alephiumConnect'
 
 type AlephiumConnectProviderProps = {
   useTheme?: Theme
@@ -51,7 +47,7 @@ export const AlephiumConnectProvider: React.FC<AlephiumConnectProviderProps> = (
 }) => {
   // Only allow for mounting AlephiumConnectProvider once, so we avoid weird global
   // state collisions.
-  const context = useAlephiumConnectContext()
+  const context = useContext(AlephiumConnectContext)
   if (context) {
     throw new Error('Multiple, nested usages of AlephiumConnectProvider detected. Please use only one.')
   }
@@ -61,7 +57,7 @@ export const AlephiumConnectProvider: React.FC<AlephiumConnectProviderProps> = (
   const [customTheme, setCustomTheme] = useState<CustomTheme>(useCustomTheme ?? {})
 
   const [open, setOpen] = useState<boolean>(false)
-  const [connector, setConnector] = useState<string>('')
+  const [connectorId, setConnectorId] = useState<AlephiumConnectContextValue['connectorId']>('')
   const [route, setRoute] = useState<string>(routes.CONNECTORS)
   const [account, setAccount] = useState<Account>()
   const [errorMessage, setErrorMessage] = useState<AlephiumConnectContextValue['errorMessage']>('')
@@ -76,8 +72,8 @@ export const AlephiumConnectProvider: React.FC<AlephiumConnectProviderProps> = (
     setOpen,
     route,
     setRoute,
-    connector,
-    setConnector,
+    connectorId,
+    setConnectorId,
     account,
     setAccount,
     signerProvider,

--- a/packages/web3-react/src/components/AlephiumConnect.tsx
+++ b/packages/web3-react/src/components/AlephiumConnect.tsx
@@ -15,7 +15,7 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
-import React, { createContext, createElement, useEffect, useState } from 'react'
+import React, { createContext, useEffect, useState } from 'react'
 
 import defaultTheme from '../styles/defaultTheme'
 
@@ -129,14 +129,12 @@ export const AlephiumConnectProvider: React.FC<AlephiumConnectProviderProps> = (
     errorMessage
   }
 
-  return createElement(
-    Context.Provider,
-    { value },
-    <>
+  return (
+    <Context.Provider value={value}>
       <ThemeProvider theme={defaultTheme}>
         {children}
         <AlephiumConnectModal theme={theme} mode={mode} customTheme={customTheme} />
       </ThemeProvider>
-    </>
+    </Context.Provider>
   )
 }

--- a/packages/web3-react/src/components/AlephiumConnect.tsx
+++ b/packages/web3-react/src/components/AlephiumConnect.tsx
@@ -25,9 +25,9 @@ import { Account, KeyType, SignerProvider } from '@alephium/web3'
 import { Theme, Mode, CustomTheme } from '../types'
 
 export const routes = {
-  CONNECTORS: 'connectors',
-  PROFILE: 'profile',
-  CONNECT: 'connect'
+  CONNECTORS: 'CONNECTORS',
+  PROFILE: 'PROFILE',
+  CONNECT: 'CONNECT'
 }
 
 type Connector = any

--- a/packages/web3-react/src/components/Common/Modal/index.tsx
+++ b/packages/web3-react/src/components/Common/Modal/index.tsx
@@ -40,13 +40,12 @@ import {
   ErrorMessage
 } from './styles'
 
-import { routes, useContext } from '../../AlephiumConnect'
-
 import { useTransition } from 'react-transition-state'
 import FocusTrap from '../../../hooks/useFocusTrap'
 import usePrevious from '../../../hooks/usePrevious'
 import FitText from '../FitText'
 import { ResetContainer } from '../../../styles'
+import { useAlephiumConnectContext } from '../../../contexts/alephiumConnect'
 
 const InfoIcon = ({ ...props }) => (
   <svg
@@ -109,6 +108,12 @@ export const contentVariants: Variants = {
   }
 }
 
+export const routes = {
+  CONNECTORS: 'CONNECTORS',
+  PROFILE: 'PROFILE',
+  CONNECT: 'CONNECT'
+}
+
 export type Page = {
   id: keyof typeof routes
   content: ReactNode
@@ -125,7 +130,7 @@ type ModalProps = {
   onInfo?: () => void
 }
 const Modal: React.FC<ModalProps> = ({ open, pages, pageId, positionInside, inline, onClose, onBack, onInfo }) => {
-  const context = useContext()
+  const context = useAlephiumConnectContext()
   const mobile = isMobile()
 
   const [state, setOpen] = useTransition({

--- a/packages/web3-react/src/components/Common/Modal/index.tsx
+++ b/packages/web3-react/src/components/Common/Modal/index.tsx
@@ -15,7 +15,7 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { ReactNode, useCallback, useEffect, useRef, useState } from 'react'
 
 import { AnimatePresence, motion, Variants } from 'framer-motion'
 
@@ -109,9 +109,14 @@ export const contentVariants: Variants = {
   }
 }
 
+export type Page = {
+  id: keyof typeof routes
+  content: ReactNode
+}
+
 type ModalProps = {
   open?: boolean
-  pages: any
+  pages: Page[]
   pageId: string
   positionInside?: boolean
   inline?: boolean
@@ -359,30 +364,27 @@ const Modal: React.FC<ModalProps> = ({ open, pages, pageId, positionInside, inli
             </ModalHeading>
 
             <InnerContainer>
-              {Object.keys(pages).map((key) => {
-                const page = pages[key]
-                return (
-                  // TODO: We may need to use the follow check avoid unnecessary computations, but this causes a bug where the content flashes
-                  // (key === pageId || key === prevPage) && (
-                  <Page
-                    key={key}
-                    open={key === pageId}
-                    initial={!positionInside && state !== 'entered'}
-                    enterAnim={key === pageId ? (currentDepth > prevDepth ? 'active-scale-up' : 'active') : ''}
-                    exitAnim={key !== pageId ? (currentDepth < prevDepth ? 'exit-scale-down' : 'exit') : ''}
+              {pages.map(({ id, content }) => (
+                // TODO: We may need to use the follow check avoid unnecessary computations, but this causes a bug where the content flashes
+                // (key === pageId || key === prevPage) && (
+                <Page
+                  key={id}
+                  open={id === pageId}
+                  initial={!positionInside && state !== 'entered'}
+                  enterAnim={id === pageId ? (currentDepth > prevDepth ? 'active-scale-up' : 'active') : ''}
+                  exitAnim={id !== pageId ? (currentDepth < prevDepth ? 'exit-scale-down' : 'exit') : ''}
+                >
+                  <PageContents
+                    key={`inner-${id}`}
+                    ref={contentRef}
+                    style={{
+                      pointerEvents: id === pageId && rendered ? 'auto' : 'none'
+                    }}
                   >
-                    <PageContents
-                      key={`inner-${key}`}
-                      ref={contentRef}
-                      style={{
-                        pointerEvents: key === pageId && rendered ? 'auto' : 'none'
-                      }}
-                    >
-                      {page}
-                    </PageContents>
-                  </Page>
-                )
-              })}
+                    {content}
+                  </PageContents>
+                </Page>
+              ))}
             </InnerContainer>
           </BoxContainer>
         </Container>

--- a/packages/web3-react/src/components/Common/Tooltip/index.tsx
+++ b/packages/web3-react/src/components/Common/Tooltip/index.tsx
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
-import { useContext } from '../../AlephiumConnect'
+import { useAlephiumConnectContext } from '../../../contexts/alephiumConnect'
 import useMeasure from 'react-use-measure'
 
 import { TooltipProps, TooltipSizeProps } from './types'
@@ -27,7 +27,7 @@ import Portal from '../Portal'
 import { ResetContainer } from '../../../styles'
 
 const Tooltip: React.FC<TooltipProps> = ({ children, message, open, xOffset = 0, yOffset = 0, delay }) => {
-  const context = useContext()
+  const context = useAlephiumConnectContext()
 
   const [isOpen, setIsOpen] = useState(false)
   const [outOfBounds, setOutOfBounds] = useState(false)

--- a/packages/web3-react/src/components/ConnectButton/index.tsx
+++ b/packages/web3-react/src/components/ConnectButton/index.tsx
@@ -19,13 +19,14 @@ import React from 'react'
 import useIsMounted from '../../hooks/useIsMounted'
 
 import { TextContainer } from './styles'
-import { routes, useContext } from '../AlephiumConnect'
+import { useAlephiumConnectContext } from '../../contexts/alephiumConnect'
 import { AnimatePresence, Variants } from 'framer-motion'
 import ThemedButton, { ThemeContainer } from '../Common/ThemedButton'
 import { ResetContainer } from '../../styles'
 import { useAccount } from '../../hooks/useAccount'
 import { truncatedAddress } from '../../utils'
 import { Account } from '@alephium/web3'
+import { routes } from '../Common/Modal'
 
 const contentVariants: Variants = {
   initial: {
@@ -116,7 +117,7 @@ type ConnectButtonRendererProps = {
 
 const ConnectButtonRenderer: React.FC<ConnectButtonRendererProps> = ({ displayAccount, children }) => {
   const isMounted = useIsMounted()
-  const context = useContext()
+  const context = useAlephiumConnectContext()
 
   const { account } = useAccount()
   const isConnected = false
@@ -160,7 +161,7 @@ function AlephiumConnectButtonInner({
   separator?: string
   displayAccount: (account: Account) => string
 }) {
-  const context = useContext()
+  const context = useAlephiumConnectContext()
   const { account } = useAccount()
 
   return (
@@ -230,7 +231,7 @@ type AlephiumConnectButtonProps = {
 export function AlephiumConnectButton({ label, onClick, displayAccount }: AlephiumConnectButtonProps) {
   const isMounted = useIsMounted()
 
-  const context = useContext()
+  const context = useAlephiumConnectContext()
   const { isConnected } = useAccount()
 
   function show() {

--- a/packages/web3-react/src/components/ConnectModal/ConnectWithInjector/index.tsx
+++ b/packages/web3-react/src/components/ConnectModal/ConnectWithInjector/index.tsx
@@ -19,7 +19,7 @@ import React, { useEffect, useState } from 'react'
 import { AnimatePresence, Variants } from 'framer-motion'
 import { Container, ConnectingContainer, ConnectingAnimation, RetryButton, RetryIconContainer, Content } from './styles'
 
-import { useContext } from '../../AlephiumConnect'
+import { useAlephiumConnectContext } from '../../../contexts/alephiumConnect'
 import supportedConnectors from '../../../constants/supportedConnectors'
 
 import {
@@ -87,7 +87,7 @@ const ConnectWithInjector: React.FC<{
   switchConnectMethod: (id?: string) => void
   forceState?: typeof states
 }> = ({ connectorId, switchConnectMethod, forceState }) => {
-  const context = useContext()
+  const context = useAlephiumConnectContext()
 
   const { connect } = useConnect({
     chainGroup: context.addressGroup,

--- a/packages/web3-react/src/components/ConnectModal/ConnectWithWalletConnect.tsx
+++ b/packages/web3-react/src/components/ConnectModal/ConnectWithWalletConnect.tsx
@@ -17,14 +17,14 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 import React, { useEffect, useState } from 'react'
 import { PageContent } from '../Common/Modal/styles'
-import { useContext } from '../AlephiumConnect'
+import { useAlephiumConnectContext } from '../../contexts/alephiumConnect'
 import { Container } from './ConnectWithInjector/styles'
 import { useConnect } from '../../hooks/useConnect'
 
 let _init = false
 
 const ConnectWithWalletConnect: React.FC = () => {
-  const context = useContext()
+  const context = useAlephiumConnectContext()
   const [error, setError] = useState<string>()
   const { connect } = useConnect({
     chainGroup: context.addressGroup,

--- a/packages/web3-react/src/components/ConnectModal/ConnectWithWalletConnect.tsx
+++ b/packages/web3-react/src/components/ConnectModal/ConnectWithWalletConnect.tsx
@@ -25,7 +25,7 @@ let _init = false
 
 const ConnectWithWalletConnect: React.FC = () => {
   const context = useContext()
-  const [error, setError] = useState<string | undefined>(undefined)
+  const [error, setError] = useState<string>()
   const { connect } = useConnect({
     chainGroup: context.addressGroup,
     keyType: context.keyType,

--- a/packages/web3-react/src/components/ConnectModal/index.tsx
+++ b/packages/web3-react/src/components/ConnectModal/index.tsx
@@ -16,8 +16,8 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 import { useEffect } from 'react'
-import { routes, useContext } from '../AlephiumConnect'
-import Modal, { Page } from '../Common/Modal'
+import { useAlephiumConnectContext } from '../../contexts/alephiumConnect'
+import Modal, { Page, routes } from '../Common/Modal'
 
 import Connectors from '../Pages/Connectors'
 import ConnectUsing from './ConnectUsing'
@@ -32,7 +32,7 @@ const ConnectModal: React.FC<{
   theme?: Theme
   customTheme?: CustomTheme
 }> = ({ mode = 'auto', theme = 'auto', customTheme = customThemeDefault }) => {
-  const context = useContext()
+  const context = useAlephiumConnectContext()
   const { isConnected } = useAccount()
 
   const closeable = true

--- a/packages/web3-react/src/components/ConnectModal/index.tsx
+++ b/packages/web3-react/src/components/ConnectModal/index.tsx
@@ -17,7 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 import { useEffect } from 'react'
 import { routes, useContext } from '../AlephiumConnect'
-import Modal from '../Common/Modal'
+import Modal, { Page } from '../Common/Modal'
 
 import Connectors from '../Pages/Connectors'
 import ConnectUsing from './ConnectUsing'
@@ -43,11 +43,11 @@ const ConnectModal: React.FC<{
     context.setRoute(routes.CONNECTORS)
   }
 
-  const pages: any = {
-    connectors: <Connectors />,
-    connect: <ConnectUsing connectorId={context.connector} />,
-    profile: <Profile />
-  }
+  const pages: Page[] = [
+    { id: 'CONNECTORS', content: <Connectors /> },
+    { id: 'CONNECT', content: <ConnectUsing connectorId={context.connector} /> },
+    { id: 'PROFILE', content: <Profile /> }
+  ]
 
   function hide() {
     context.setOpen(false)

--- a/packages/web3-react/src/components/ConnectModal/index.tsx
+++ b/packages/web3-react/src/components/ConnectModal/index.tsx
@@ -45,7 +45,7 @@ const ConnectModal: React.FC<{
 
   const pages: Page[] = [
     { id: 'CONNECTORS', content: <Connectors /> },
-    { id: 'CONNECT', content: <ConnectUsing connectorId={context.connector} /> },
+    { id: 'CONNECT', content: <ConnectUsing connectorId={context.connectorId} /> },
     { id: 'PROFILE', content: <Profile /> }
   ]
 

--- a/packages/web3-react/src/components/Pages/Connectors/index.tsx
+++ b/packages/web3-react/src/components/Pages/Connectors/index.tsx
@@ -72,7 +72,7 @@ const Connectors: React.FC = () => {
                   //disabled={!connector.ready}
                   onClick={() => {
                     context.setRoute(routes.CONNECT)
-                    context.setConnector(connector.id)
+                    context.setConnectorId(connector.id)
                   }}
                 >
                   <MobileConnectorIcon>
@@ -116,7 +116,7 @@ const Connectors: React.FC = () => {
                   onClick={() => {
                     //connect()
                     context.setRoute(routes.CONNECT)
-                    context.setConnector(connector.id)
+                    context.setConnectorId(connector.id)
                   }}
                 >
                   <ConnectorIcon>{logo}</ConnectorIcon>

--- a/packages/web3-react/src/components/Pages/Connectors/index.tsx
+++ b/packages/web3-react/src/components/Pages/Connectors/index.tsx
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 import React from 'react'
-import { useContext, routes } from '../../AlephiumConnect'
+import { useAlephiumConnectContext } from '../../../contexts/alephiumConnect'
 import supportedConnectors from '../../../constants/supportedConnectors'
 
 import { PageContent } from '../../Common/Modal/styles'
@@ -35,9 +35,10 @@ import {
 import { isMobile } from '../../../utils'
 import useDefaultWallets from '../../../wallets/useDefaultWallets'
 import { WalletProps } from '../../../wallets/wallet'
+import { routes } from '../../Common/Modal'
 
 const Connectors: React.FC = () => {
-  const context = useContext()
+  const context = useAlephiumConnectContext()
   const mobile = isMobile()
   const wallets = useDefaultWallets()
 

--- a/packages/web3-react/src/components/Pages/Connectors/index.tsx
+++ b/packages/web3-react/src/components/Pages/Connectors/index.tsx
@@ -34,28 +34,12 @@ import {
 
 import { isMobile } from '../../../utils'
 import useDefaultWallets from '../../../wallets/useDefaultWallets'
+import { WalletProps } from '../../../wallets/wallet'
 
 const Connectors: React.FC = () => {
   const context = useContext()
   const mobile = isMobile()
   const wallets = useDefaultWallets()
-
-  const findInjectedConnectorInfo = (name: string) => {
-    let walletList = name.split(/[(),]+/)
-    walletList.shift() // remove "Injected" from array
-    walletList = walletList.map((x) => x.trim())
-
-    const hasWalletLogo = walletList.filter((x) => {
-      const a = wallets.map((wallet: any) => wallet.name).includes(x)
-      if (a) return x
-      return null
-    })
-    if (hasWalletLogo.length === 0) return null
-
-    const foundInjector = wallets.filter((wallet: any) => wallet.installed && wallet.name === hasWalletLogo[0])[0]
-
-    return foundInjector
-  }
 
   return (
     <PageContent style={{ width: 312 }}>
@@ -69,8 +53,8 @@ const Connectors: React.FC = () => {
               let logos = info.logos
               let name = info.shortName ?? info.name ?? connector.name
 
-              if (info.id === 'injected') {
-                const foundInjector = findInjectedConnectorInfo(connector.name ?? '')
+              if (info.id === 'injected' && connector.name) {
+                const foundInjector = findInjectedConnectorInfo(connector.name, wallets)
                 if (foundInjector) {
                   logos = foundInjector.logos
                   name = foundInjector.name.replace(' Wallet', '')
@@ -107,14 +91,10 @@ const Connectors: React.FC = () => {
               if (!info) return null
 
               let logos = info.logos
+              let name = info.id === 'walletConnect' ? 'WalletConnect' : info.name ?? connector.name
 
-              let name = info.name ?? connector.name
-              if (info.id === 'walletConnect') {
-                name = 'Wallet Connect'
-              }
-
-              if (info.id === 'injected') {
-                const foundInjector = findInjectedConnectorInfo(connector.name ?? '')
+              if (info.id === 'injected' && connector.name) {
+                const foundInjector = findInjectedConnectorInfo(connector.name, wallets)
                 if (foundInjector) {
                   logos = foundInjector.logos
                   name = foundInjector.name
@@ -127,6 +107,7 @@ const Connectors: React.FC = () => {
                   logo = logos.appIcon
                 }
               }
+
               return (
                 <ConnectorButton
                   key={connector.id}
@@ -150,3 +131,20 @@ const Connectors: React.FC = () => {
 }
 
 export default Connectors
+
+const findInjectedConnectorInfo = (name: string, wallets: WalletProps[]) => {
+  let walletList = name.split(/[(),]+/)
+  walletList.shift() // remove "Injected" from array
+  walletList = walletList.map((x) => x.trim())
+
+  const hasWalletLogo = walletList.filter((x) => {
+    const a = wallets.map((wallet) => wallet.name).includes(x)
+    if (a) return x
+    return null
+  })
+  if (hasWalletLogo.length === 0) return null
+
+  const foundInjector = wallets.filter((wallet) => wallet.installed && wallet.name === hasWalletLogo[0])[0]
+
+  return foundInjector
+}

--- a/packages/web3-react/src/components/Pages/Connectors/index.tsx
+++ b/packages/web3-react/src/components/Pages/Connectors/index.tsx
@@ -35,7 +35,7 @@ import {
 import { isMobile } from '../../../utils'
 import useDefaultWallets from '../../../wallets/useDefaultWallets'
 
-const Wallets: React.FC = () => {
+const Connectors: React.FC = () => {
   const context = useContext()
   const mobile = isMobile()
   const wallets = useDefaultWallets()
@@ -149,4 +149,4 @@ const Wallets: React.FC = () => {
   )
 }
 
-export default Wallets
+export default Connectors

--- a/packages/web3-react/src/components/Pages/Profile/index.tsx
+++ b/packages/web3-react/src/components/Pages/Profile/index.tsx
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 import React, { useEffect, useState } from 'react'
-import { useContext } from '../../AlephiumConnect'
+import { useAlephiumConnectContext } from '../../../contexts/alephiumConnect'
 
 import { PageContent, ModalBody, ModalContent, ModalH1 } from '../../Common/Modal/styles'
 import Button from '../../Common/Button'
@@ -32,7 +32,7 @@ import { prettifyAttoAlphAmount } from '@alephium/web3'
 import { useConnect } from '../../../hooks/useConnect'
 
 const Profile: React.FC<{ closeModal?: () => void }> = ({ closeModal }) => {
-  const context = useContext()
+  const context = useAlephiumConnectContext()
   const { account } = useAccount()
   const { balance } = useBalance()
   const { disconnect } = useConnect({

--- a/packages/web3-react/src/constants/supportedConnectors.tsx
+++ b/packages/web3-react/src/constants/supportedConnectors.tsx
@@ -15,28 +15,8 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
-import { ReactNode } from 'react'
+import { Connector } from '../types'
 import Logos from './../assets/logos'
-
-type Connector = {
-  id: string
-  name?: string
-  shortName?: string
-  logos: {
-    default: ReactNode
-    transparent?: ReactNode
-    connectorButton?: ReactNode
-    qrCode?: ReactNode
-    appIcon?: ReactNode
-    mobile?: ReactNode
-  }
-  logoBackground?: string
-  scannable?: boolean
-  extensions?: { [key: string]: string }
-  appUrls?: { [key: string]: string }
-  extensionIsInstalled?: () => boolean
-  defaultConnect?: () => void
-}
 
 let supportedConnectors: Connector[] = []
 

--- a/packages/web3-react/src/constants/supportedConnectors.tsx
+++ b/packages/web3-react/src/constants/supportedConnectors.tsx
@@ -18,7 +18,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import { ReactNode } from 'react'
 import Logos from './../assets/logos'
 
-let supportedConnectors: {
+type Connector = {
   id: string
   name?: string
   shortName?: string
@@ -34,15 +34,13 @@ let supportedConnectors: {
   scannable?: boolean
   extensions?: { [key: string]: string }
   appUrls?: { [key: string]: string }
-  extensionIsInstalled?: () => any
-  defaultConnect?: () => any
-}[] = []
+  extensionIsInstalled?: () => boolean
+  defaultConnect?: () => void
+}
+
+let supportedConnectors: Connector[] = []
 
 if (typeof window != 'undefined') {
-  interface IDictionary {
-    [index: string]: string
-  }
-
   supportedConnectors = [
     {
       id: 'injected',
@@ -100,8 +98,7 @@ if (typeof window != 'undefined') {
         qrCode: <Logos.WalletConnect background={true} />
       },
       logoBackground: 'var(--ck-brand-walletConnect)',
-      scannable: true,
-      defaultConnect: () => {}
+      scannable: true
     }
   ]
 }

--- a/packages/web3-react/src/contexts/alephiumConnect.tsx
+++ b/packages/web3-react/src/contexts/alephiumConnect.tsx
@@ -18,9 +18,8 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import React, { createContext, useContext } from 'react'
 
 import { Account, KeyType, SignerProvider } from '@alephium/web3'
-import { Theme, Mode, CustomTheme } from '../types'
+import { Theme, Mode, CustomTheme, Connector } from '../types'
 
-type Connector = any
 type Error = string | React.ReactNode | null
 
 export type AlephiumConnectContextValue = {
@@ -29,8 +28,8 @@ export type AlephiumConnectContextValue = {
   route: string
   setRoute: React.Dispatch<React.SetStateAction<string>>
   errorMessage: Error
-  connector: Connector
-  setConnector: React.Dispatch<React.SetStateAction<Connector>>
+  connectorId: Connector['id']
+  setConnectorId: React.Dispatch<React.SetStateAction<Connector['id']>>
   account?: Account
   setAccount: React.Dispatch<React.SetStateAction<Account | undefined>>
   displayAccount?: (account: Account) => string

--- a/packages/web3-react/src/contexts/alephiumConnect.tsx
+++ b/packages/web3-react/src/contexts/alephiumConnect.tsx
@@ -1,0 +1,57 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+import React, { createContext, useContext } from 'react'
+
+import { Account, KeyType, SignerProvider } from '@alephium/web3'
+import { Theme, Mode, CustomTheme } from '../types'
+
+type Connector = any
+type Error = string | React.ReactNode | null
+
+export type AlephiumConnectContextValue = {
+  open: boolean
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>
+  route: string
+  setRoute: React.Dispatch<React.SetStateAction<string>>
+  errorMessage: Error
+  connector: Connector
+  setConnector: React.Dispatch<React.SetStateAction<Connector>>
+  account?: Account
+  setAccount: React.Dispatch<React.SetStateAction<Account | undefined>>
+  displayAccount?: (account: Account) => string
+  signerProvider?: SignerProvider
+  setSignerProvider: React.Dispatch<React.SetStateAction<SignerProvider | undefined>>
+  addressGroup?: number
+  keyType?: KeyType
+  network?: string
+  networkId?: number
+  theme: Theme
+  setTheme: React.Dispatch<React.SetStateAction<Theme>>
+  mode: Mode
+  setMode: React.Dispatch<React.SetStateAction<Mode>>
+  customTheme: CustomTheme
+  setCustomTheme: React.Dispatch<React.SetStateAction<CustomTheme>>
+}
+
+export const AlephiumConnectContext = createContext<AlephiumConnectContextValue | null>(null)
+
+export const useAlephiumConnectContext = () => {
+  const context = useContext(AlephiumConnectContext)
+  if (!context) throw Error('AlephiumConnect Hook must be inside a Provider.')
+  return context
+}

--- a/packages/web3-react/src/hooks/useAccount.tsx
+++ b/packages/web3-react/src/hooks/useAccount.tsx
@@ -25,7 +25,7 @@ export function useAccount(onDisconnected?: () => Promise<void>) {
 
   useEffect(() => {
     const handler = async () => {
-      if (context.connector === 'walletConnect') {
+      if (context.connectorId === 'walletConnect') {
         return
       }
 

--- a/packages/web3-react/src/hooks/useAccount.tsx
+++ b/packages/web3-react/src/hooks/useAccount.tsx
@@ -17,11 +17,11 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 import { getDefaultAlephiumWallet } from '@alephium/get-extension-wallet'
 import { useEffect } from 'react'
-import { useContext } from '../components/AlephiumConnect'
+import { useAlephiumConnectContext } from '../contexts/alephiumConnect'
 import { KeyType } from '@alephium/web3'
 
 export function useAccount(onDisconnected?: () => Promise<void>) {
-  const context = useContext()
+  const context = useAlephiumConnectContext()
 
   useEffect(() => {
     const handler = async () => {

--- a/packages/web3-react/src/hooks/useBalance.tsx
+++ b/packages/web3-react/src/hooks/useBalance.tsx
@@ -17,10 +17,10 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 import { Balance } from '@alephium/web3/dist/src/api/api-alephium'
 import { useEffect, useState } from 'react'
-import { useContext } from '../components/AlephiumConnect'
+import { useAlephiumConnectContext } from '../contexts/alephiumConnect'
 
 export function useBalance() {
-  const context = useContext()
+  const context = useAlephiumConnectContext()
   const [balance, setBalance] = useState<Balance>()
 
   useEffect(() => {

--- a/packages/web3-react/src/hooks/useConnect.tsx
+++ b/packages/web3-react/src/hooks/useConnect.tsx
@@ -17,14 +17,14 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 import { getDefaultAlephiumWallet } from '@alephium/get-extension-wallet'
 import type { EnableOptionsBase } from '@alephium/web3'
-import { useContext } from '../components/AlephiumConnect'
-import { useCallback, useMemo } from 'react'
+import { useAlephiumConnectContext } from '../contexts/alephiumConnect'
+import { useCallback, useMemo, useState } from 'react'
 import { WalletConnectProvider, QRCodeModal } from '@alephium/walletconnect-provider'
 
 export type ConnectOptions = Omit<EnableOptionsBase, 'onDisconnected'>
 
 export function useConnect(options: ConnectOptions) {
-  const context = useContext()
+  const context = useAlephiumConnectContext()
   const wcConnect = useCallback(async () => {
     if (context.network === undefined) {
       throw new Error('No network id specified')

--- a/packages/web3-react/src/hooks/useConnect.tsx
+++ b/packages/web3-react/src/hooks/useConnect.tsx
@@ -53,7 +53,7 @@ export function useConnect(options: ConnectOptions) {
   }, [context])
 
   const wcDisconnect = useCallback(async () => {
-    if (context.connector === 'walletConnect' && context.signerProvider) {
+    if (context.connectorId === 'walletConnect' && context.signerProvider) {
       await (context.signerProvider as WalletConnectProvider).disconnect()
       context.setSignerProvider(undefined)
       context.setAccount(undefined)
@@ -93,7 +93,7 @@ export function useConnect(options: ConnectOptions) {
   }, [context])
 
   return useMemo(() => {
-    if (context.connector === 'walletConnect') {
+    if (context.connectorId === 'walletConnect') {
       return { connect: wcConnect, disconnect: wcDisconnect }
     }
     return { connect: connectAlephium, disconnect: disconnectAlephium }

--- a/packages/web3-react/src/index.ts
+++ b/packages/web3-react/src/index.ts
@@ -15,7 +15,8 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
-export { AlephiumConnectProvider, useContext } from './components/AlephiumConnect'
+export { AlephiumConnectProvider } from './components/AlephiumConnect'
+export { useAlephiumConnectContext } from './contexts/alephiumConnect'
 export { AlephiumConnectButton } from './components/ConnectButton'
 
 export { default as supportedConnectors } from './constants/supportedConnectors'

--- a/packages/web3-react/src/types.ts
+++ b/packages/web3-react/src/types.ts
@@ -15,6 +15,28 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
+import { ReactNode } from 'react'
+
 export type Theme = 'auto' | 'web95' | 'retro' | 'soft' | 'midnight' | 'minimal' | 'rounded' | 'nouns'
 export type Mode = 'light' | 'dark' | 'auto'
 export type CustomTheme = any // TODO: define type
+
+export type Connector = {
+  id: string
+  name?: string
+  shortName?: string
+  logos: {
+    default: ReactNode
+    transparent?: ReactNode
+    connectorButton?: ReactNode
+    qrCode?: ReactNode
+    appIcon?: ReactNode
+    mobile?: ReactNode
+  }
+  logoBackground?: string
+  scannable?: boolean
+  extensions?: { [key: string]: string }
+  appUrls?: { [key: string]: string }
+  extensionIsInstalled?: () => boolean
+  defaultConnect?: () => void
+}

--- a/packages/web3-react/src/wallets/useDefaultWallets.tsx
+++ b/packages/web3-react/src/wallets/useDefaultWallets.tsx
@@ -18,7 +18,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import { getWallets } from './'
 import { WalletProps } from './wallet'
 
-function useDefaultWallets(): WalletProps[] | any {
+function useDefaultWallets(): WalletProps[] {
   return getWallets({})
 }
 


### PR DESCRIPTION
While trying to use a local version of the `web3-react` package in the [nft-prototype project](https://github.com/alephium/alephium-nft) so that I can work on the WalletConnect compatibility with the desktop wallet, I've been encountering an error where `React` is `null`. I thought this might be related to the circular imports #150  that I noticed in the package. It wasn't related to that, I am still facing this error. Nevertheless, this PR fixes the circular imports and improves some typing.