### PR TITLE
Use the network id from @alephium/web3

### DIFF
--- a/packages/get-extension-wallet/src/types.ts
+++ b/packages/get-extension-wallet/src/types.ts
@@ -15,7 +15,7 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
-import { Account, EnableOptionsBase, InteractiveSignerProvider } from '@alephium/web3'
+import { Account, EnableOptionsBase, InteractiveSignerProvider, NetworkId } from '@alephium/web3'
 
 export type EnableOptions = EnableOptionsBase
 
@@ -36,7 +36,7 @@ export abstract class AlephiumWindowObject extends InteractiveSignerProvider<Ena
   }
 
   abstract get connectedAccount(): Account | undefined
-  abstract get connectedNetworkId(): string | undefined
+  abstract get connectedNetworkId(): NetworkId | undefined
 }
 
 export type WalletProvider = {

--- a/packages/get-extension-wallet/tsconfig.json
+++ b/packages/get-extension-wallet/tsconfig.json
@@ -1,13 +1,9 @@
 {
+  "extends": "../../tsconfig.json",
   "include": ["src/**/*"],
   "exclude": ["**/node_modules/**/*", "**/dist/**/*"],
-
   "compilerOptions": {
-    "outDir": "./dist/",
-    "target": "ES2020",
-    "declaration": true,
-    "declarationMap": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true
-  }
+    "outDir": "dist",
+    "declarationDir": "dist"
+  },
 }

--- a/packages/walletconnect/src/provider.ts
+++ b/packages/walletconnect/src/provider.ts
@@ -36,7 +36,9 @@ import {
   addressFromPublicKey,
   NodeProvider,
   ExplorerProvider,
-  ApiRequestArguments
+  ApiRequestArguments,
+  NetworkId,
+  networkIds
 } from '@alephium/web3'
 
 import { LOGGER, PROVIDER_NAMESPACE, RELAY_METHODS, RELAY_URL } from './constants'
@@ -48,8 +50,7 @@ import {
   ProviderEventArgument,
   RelayMethod,
   ProjectMetaData,
-  ChainInfo,
-  NetworkId
+  ChainInfo
 } from './types'
 
 export interface ProviderOptions {
@@ -369,7 +370,11 @@ export function parseChain(chainString: string): ChainInfo {
   if (chainGroupDecoded < -1) {
     throw Error('Chain group in protocol needs to be either -1 or non-negative')
   }
-  return { networkId: networkId, chainGroup: chainGroupDecoded === -1 ? undefined : chainGroupDecoded }
+  const networkIdList = networkIds as ReadonlyArray<string>
+  if (!networkIdList.includes(networkId)) {
+    throw Error(`Invalid network id, expect one of ${networkIdList}`)
+  }
+  return { networkId: networkId as NetworkId, chainGroup: chainGroupDecoded === -1 ? undefined : chainGroupDecoded }
 }
 
 export function formatAccount(permittedChain: string, account: Account): string {

--- a/packages/walletconnect/src/types.ts
+++ b/packages/walletconnect/src/types.ts
@@ -29,7 +29,8 @@ import {
   SignMessageResult,
   ApiRequestArguments,
   assertType,
-  Eq
+  Eq,
+  NetworkId
 } from '@alephium/web3'
 import { SignClientTypes } from '@walletconnect/types'
 import { RELAY_METHODS } from './constants'
@@ -94,7 +95,6 @@ export type ProviderEvent =
 assertType<Eq<ProviderEvent, keyof ProviderEventArguments>>()
 export type ProviderEventArgument<T extends ProviderEvent> = ProviderEventArguments[T]
 
-export type NetworkId = string
 export type ChainGroup = number | undefined // number: a specific address group; undefined: all address groups
 export interface ChainInfo {
   networkId: NetworkId

--- a/packages/walletconnect/test/shared/WalletClient.ts
+++ b/packages/walletconnect/test/shared/WalletClient.ts
@@ -26,7 +26,8 @@ import {
   SignMessageParams,
   Account,
   addressToGroup,
-  ApiRequestArguments
+  ApiRequestArguments,
+  NetworkId
 } from '@alephium/web3'
 import { PrivateKeyWallet } from '@alephium/web3-wallet'
 
@@ -38,8 +39,7 @@ import {
   isCompatibleChainGroup,
   RelayMethod,
   WalletConnectProvider,
-  formatAccount,
-  NetworkId
+  formatAccount
 } from '../../src'
 import SignClient from '@walletconnect/sign-client'
 import { getSdkError } from '@walletconnect/utils'
@@ -94,7 +94,7 @@ export class WalletClient {
 
   constructor(provider: WalletConnectProvider, opts: Partial<WalletClientOpts>) {
     this.provider = provider
-    this.networkId = opts?.networkId ?? ''
+    this.networkId = opts?.networkId ?? 'devnet'
     this.rpcUrl = opts?.rpcUrl || 'http://alephium:22973'
     this.permittedChainGroup = undefined
     this.nodeProvider = new NodeProvider(this.rpcUrl)

--- a/packages/walletconnect/test/walletconnect.test.ts
+++ b/packages/walletconnect/test/walletconnect.test.ts
@@ -15,9 +15,9 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
-import { formatChain, NetworkId, parseChain, ProviderOptions, WalletConnectProvider } from '../src/index'
+import { formatChain, parseChain, ProviderOptions, WalletConnectProvider } from '../src/index'
 import { WalletClient } from './shared'
-import { web3, node, NodeProvider, verifySignedMessage, Project, groupOfAddress } from '@alephium/web3'
+import { web3, node, NodeProvider, verifySignedMessage, Project, groupOfAddress, NetworkId } from '@alephium/web3'
 import { PrivateKeyWallet } from '@alephium/web3-wallet'
 import { SignClientTypes } from '@walletconnect/types'
 import { Greeter, Main } from '../artifacts/ts'
@@ -83,7 +83,7 @@ const TEST_PROVIDER_OPTS: ProviderOptions = {
 }
 
 const TEST_WALLET_CLIENT_OPTS = {
-  networkId: NETWORK_ID,
+  networkId: NETWORK_ID as NetworkId,
   rpcUrl: RPC_URL,
   activePrivateKey: ACCOUNTS.a.privateKey,
   relayUrl: TEST_RELAY_URL,


### PR DESCRIPTION
Forgot to update this 😓 , but fortunately it doesn't affect testing.

And it seems we also need to update these two places:

1. https://github.com/alephium/alephium-web3/blob/535b739e698cf3c795d88abbd1bba9ec9ec2069b/packages/get-extension-wallet/src/types.ts#L39
2. https://github.com/alephium/extension-wallet/blob/2c430cdf9d833e1dd9ca9fbd53499753aed8c8ca/packages/extension/src/inpage/alephiumWindowObject.ts#L36