### PR TITLE
Fix load deployments

### DIFF
--- a/packages/cli/src/deployment.ts
+++ b/packages/cli/src/deployment.ts
@@ -99,7 +99,20 @@ export class Deployments {
       fs.mkdirSync(dirpath, { recursive: true })
     }
     const deployments = this.deployments.map((v) => v.marshal())
-    const content = JSON.stringify(deployments.length === 1 ? deployments[0] : deployments, null, 2)
+    const content = JSON.stringify(
+      deployments.length === 1 ? deployments[0] : deployments,
+      (key, value) => {
+        if (key === 'contractInstance' && value instanceof ContractInstance) {
+          return {
+            address: value.address,
+            contractId: value.contractId,
+            groupIndex: value.groupIndex
+          }
+        }
+        return value
+      },
+      2
+    )
     await fsPromises.writeFile(filepath, content)
     // This needs to be at the end since it will check if the deployments file exists
     await genLoadDeployments(config)


### PR DESCRIPTION
When testing with the bridge, I found two bugs:

1. In the `deployments.networkId.json` file, the `contractInstance` object has a `methods` field, here is [an example](https://github.com/alephium/alephium-dex/blob/d5e546139200f65d1353d6cb2ddc09bcee114805/artifacts/.deployments.testnet.json#L19)

2. Since we imported the JSON file directly and did a type conversion, we cannot call the methods of `ContractInstance`. Therefore, after loading the JSON file, we need to create a new contract instance.