### PR TITLE
Fix explorer endpoints that return text

### DIFF
--- a/packages/web3/configs/http-client.eta
+++ b/packages/web3/configs/http-client.eta
@@ -2,6 +2,6 @@
 <% /* https://github.com/acacode/swagger-typescript-api/tree/next/templates/base/http-clients/ */ %>
 
 import 'cross-fetch/polyfill'
-import { convertHttpResponse } from './utils'
+import { convertHttpResponse, convertTextHttpResponse } from './utils'
 
 <%~ includeFile(`@base/http-clients/fetch-http-client`, it) %>

--- a/packages/web3/configs/procedure-call.eta
+++ b/packages/web3/configs/procedure-call.eta
@@ -96,4 +96,4 @@ const describeReturnType = () => {
         <%~ bodyContentKindTmpl ? `type: ${bodyContentKindTmpl},` : '' %>
         <%~ responseFormatTmpl ? `format: ${responseFormatTmpl},` : '' %>
         ...<%~ _.get(requestConfigParam, "name") %>,
-    }).then(convertHttpResponse)<%~ route.namespace ? ',' : '' %>
+    }).then(<%~ responseBodyInfo.success.schema.contentKind === 'TEXT' ? 'convertTextHttpResponse' : 'convertHttpResponse' %>)<%~ route.namespace ? ',' : '' %>

--- a/packages/web3/configs/procedure-call.eta
+++ b/packages/web3/configs/procedure-call.eta
@@ -55,6 +55,7 @@ const requestContentKind = {
 const responseContentKind = {
     "JSON": '"json"',
     "IMAGE": '"blob"',
+    "TEXT": '"text"',
     "FORM_DATA": isFetchTemplate ? '"formData"' : '"document"'
 }
 
@@ -96,4 +97,4 @@ const describeReturnType = () => {
         <%~ bodyContentKindTmpl ? `type: ${bodyContentKindTmpl},` : '' %>
         <%~ responseFormatTmpl ? `format: ${responseFormatTmpl},` : '' %>
         ...<%~ _.get(requestConfigParam, "name") %>,
-    }).then(<%~ responseBodyInfo.success.schema.contentKind === 'TEXT' ? 'convertTextHttpResponse' : 'convertHttpResponse' %>)<%~ route.namespace ? ',' : '' %>
+    }).then(<%~ responseFormatTmpl === '"text"' ? 'convertTextHttpResponse' : 'convertHttpResponse' %>)<%~ route.namespace ? ',' : '' %>

--- a/packages/web3/src/api/api-explorer.ts
+++ b/packages/web3/src/api/api-explorer.ts
@@ -346,7 +346,7 @@ export interface ValU256 {
 }
 
 import 'cross-fetch/polyfill'
-import { convertHttpResponse } from './utils'
+import { convertHttpResponse, convertTextHttpResponse } from './utils'
 
 export type QueryParamsType = Record<string | number, any>
 export type ResponseFormat = keyof Omit<Body, 'body' | 'bodyUsed'>
@@ -961,7 +961,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         method: 'GET',
         query: query,
         ...params
-      }).then(convertHttpResponse),
+      }).then(convertTextHttpResponse),
 
     /**
      * No description
@@ -1070,7 +1070,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         path: `/infos/supply/total-alph`,
         method: 'GET',
         ...params
-      }).then(convertHttpResponse),
+      }).then(convertTextHttpResponse),
 
     /**
      * @description Get the ALPH circulating supply
@@ -1084,7 +1084,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         path: `/infos/supply/circulating-alph`,
         method: 'GET',
         ...params
-      }).then(convertHttpResponse),
+      }).then(convertTextHttpResponse),
 
     /**
      * @description Get the ALPH reserved supply
@@ -1098,7 +1098,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         path: `/infos/supply/reserved-alph`,
         method: 'GET',
         ...params
-      }).then(convertHttpResponse),
+      }).then(convertTextHttpResponse),
 
     /**
      * @description Get the ALPH locked supply
@@ -1112,7 +1112,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         path: `/infos/supply/locked-alph`,
         method: 'GET',
         ...params
-      }).then(convertHttpResponse),
+      }).then(convertTextHttpResponse),
 
     /**
      * @description Get the total number of transactions
@@ -1126,7 +1126,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         path: `/infos/total-transactions`,
         method: 'GET',
         ...params
-      }).then(convertHttpResponse),
+      }).then(convertTextHttpResponse),
 
     /**
      * @description Get the average block time for each chain

--- a/packages/web3/src/api/api-explorer.ts
+++ b/packages/web3/src/api/api-explorer.ts
@@ -960,6 +960,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         path: `/addresses/${address}/export-transactions/csv`,
         method: 'GET',
         query: query,
+        format: 'text',
         ...params
       }).then(convertTextHttpResponse),
 
@@ -1069,6 +1070,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       this.request<number, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
         path: `/infos/supply/total-alph`,
         method: 'GET',
+        format: 'text',
         ...params
       }).then(convertTextHttpResponse),
 
@@ -1083,6 +1085,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       this.request<number, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
         path: `/infos/supply/circulating-alph`,
         method: 'GET',
+        format: 'text',
         ...params
       }).then(convertTextHttpResponse),
 
@@ -1097,6 +1100,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       this.request<number, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
         path: `/infos/supply/reserved-alph`,
         method: 'GET',
+        format: 'text',
         ...params
       }).then(convertTextHttpResponse),
 
@@ -1111,6 +1115,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       this.request<number, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
         path: `/infos/supply/locked-alph`,
         method: 'GET',
+        format: 'text',
         ...params
       }).then(convertTextHttpResponse),
 
@@ -1125,6 +1130,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       this.request<number, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
         path: `/infos/total-transactions`,
         method: 'GET',
+        format: 'text',
         ...params
       }).then(convertTextHttpResponse),
 

--- a/packages/web3/src/api/utils.ts
+++ b/packages/web3/src/api/utils.ts
@@ -28,6 +28,17 @@ export function convertHttpResponse<T>(response: { data: T; error?: { detail: st
   }
 }
 
+export async function convertTextHttpResponse(response: {
+  text: () => Promise<string>
+  error?: { detail: string }
+}): Promise<string> {
+  if (response.error) {
+    throw new Error(`[API Error] - ${response.error.detail}`)
+  } else {
+    return await response.text()
+  }
+}
+
 export async function retryFetch(...fetchParams: Parameters<typeof fetch>): ReturnType<typeof fetch> {
   const retry = async (retryCount: number): ReturnType<typeof fetch> => {
     const response = await fetch(...fetchParams)


### PR DESCRIPTION
I haven't tested it yet, but I think the solution looks sth like this.

This file helped: https://github.com/acacode/swagger-typescript-api/blob/next/templates/modular/procedure-call.ejs