### PR TITLE
Use `/infos/version` in the compile command

### DIFF
--- a/packages/cli/cli_internal.ts
+++ b/packages/cli/cli_internal.ts
@@ -93,7 +93,7 @@ program
         process.exit(1)
       }
       web3.setCurrentNodeProvider(nodeUrl)
-      const fullNodeVersion = (await web3.getCurrentNodeProvider().infos.getInfosNode()).buildInfo.releaseVersion
+      const fullNodeVersion = (await web3.getCurrentNodeProvider().infos.getInfosVersion()).version
       const cwd = path.resolve(process.cwd())
       await Project.build(config.compilerOptions, cwd, config.sourceDir, config.artifactDir, fullNodeVersion)
       console.log('✅ Compilation completed!')


### PR DESCRIPTION
This is to keep it consistent with [here](https://github.com/alephium/alephium-web3/blob/55e74b31a2dad5e6f5208faea75a0c593edabfb8/packages/web3/src/contract/contract.ts#L632).