### PR TITLE
Fix text endpoints

### DIFF
--- a/packages/web3/configs/http-client.eta
+++ b/packages/web3/configs/http-client.eta
@@ -2,6 +2,6 @@
 <% /* https://github.com/acacode/swagger-typescript-api/tree/next/templates/base/http-clients/ */ %>
 
 import 'cross-fetch/polyfill'
-import { convertHttpResponse, convertTextHttpResponse } from './utils'
+import { convertHttpResponse } from './utils'
 
 <%~ includeFile(`@base/http-clients/fetch-http-client`, it) %>

--- a/packages/web3/configs/procedure-call.eta
+++ b/packages/web3/configs/procedure-call.eta
@@ -97,4 +97,4 @@ const describeReturnType = () => {
         <%~ bodyContentKindTmpl ? `type: ${bodyContentKindTmpl},` : '' %>
         <%~ responseFormatTmpl ? `format: ${responseFormatTmpl},` : '' %>
         ...<%~ _.get(requestConfigParam, "name") %>,
-    }).then(<%~ responseFormatTmpl === '"text"' ? 'convertTextHttpResponse' : 'convertHttpResponse' %>)<%~ route.namespace ? ',' : '' %>
+    }).then(convertHttpResponse)<%~ route.namespace ? ',' : '' %>

--- a/packages/web3/src/api/api-explorer.ts
+++ b/packages/web3/src/api/api-explorer.ts
@@ -346,7 +346,7 @@ export interface ValU256 {
 }
 
 import 'cross-fetch/polyfill'
-import { convertHttpResponse, convertTextHttpResponse } from './utils'
+import { convertHttpResponse } from './utils'
 
 export type QueryParamsType = Record<string | number, any>
 export type ResponseFormat = keyof Omit<Body, 'body' | 'bodyUsed'>
@@ -962,7 +962,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         query: query,
         format: 'text',
         ...params
-      }).then(convertTextHttpResponse),
+      }).then(convertHttpResponse),
 
     /**
      * No description
@@ -1072,7 +1072,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         method: 'GET',
         format: 'text',
         ...params
-      }).then(convertTextHttpResponse),
+      }).then(convertHttpResponse),
 
     /**
      * @description Get the ALPH circulating supply
@@ -1087,7 +1087,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         method: 'GET',
         format: 'text',
         ...params
-      }).then(convertTextHttpResponse),
+      }).then(convertHttpResponse),
 
     /**
      * @description Get the ALPH reserved supply
@@ -1102,7 +1102,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         method: 'GET',
         format: 'text',
         ...params
-      }).then(convertTextHttpResponse),
+      }).then(convertHttpResponse),
 
     /**
      * @description Get the ALPH locked supply
@@ -1117,7 +1117,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         method: 'GET',
         format: 'text',
         ...params
-      }).then(convertTextHttpResponse),
+      }).then(convertHttpResponse),
 
     /**
      * @description Get the total number of transactions
@@ -1132,7 +1132,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         method: 'GET',
         format: 'text',
         ...params
-      }).then(convertTextHttpResponse),
+      }).then(convertHttpResponse),
 
     /**
      * @description Get the average block time for each chain

--- a/packages/web3/src/api/utils.ts
+++ b/packages/web3/src/api/utils.ts
@@ -28,17 +28,6 @@ export function convertHttpResponse<T>(response: { data: T; error?: { detail: st
   }
 }
 
-export async function convertTextHttpResponse(response: {
-  text: () => Promise<string>
-  error?: { detail: string }
-}): Promise<string> {
-  if (response.error) {
-    throw new Error(`[API Error] - ${response.error.detail}`)
-  } else {
-    return await response.text()
-  }
-}
-
 export async function retryFetch(...fetchParams: Parameters<typeof fetch>): ReturnType<typeof fetch> {
   const retry = async (retryCount: number): ReturnType<typeof fetch> => {
     const response = await fetch(...fetchParams)


### PR DESCRIPTION
@h0ngcha0, seems like the commit you added actually broke the parsing of the text endpoints response. This new PR fixes it (and also simplifies the code). All we had to do from the get-go was to simply add `"TEXT": '"text"'` in the `requestContentKind`, as you recommended.

Sorry that I didn't build the package locally after you added your commit to confirm that it still worked.