### PR TITLE
Fix webcrypto for chrome background service

### DIFF
--- a/packages/web3/src/utils/webcrypto.ts
+++ b/packages/web3/src/utils/webcrypto.ts
@@ -22,7 +22,7 @@ import { webcrypto, randomFillSync } from 'crypto'
 const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined'
 
 export class WebCrypto {
-  subtle = isBrowser ? globalThis.crypto.subtle : webcrypto.subtle
+  subtle = isBrowser ? globalThis.crypto.subtle : webcrypto ? webcrypto.subtle : crypto.subtle
 
   public getRandomValues<T extends ArrayBufferView | null>(array: T): T {
     if (!ArrayBuffer.isView(array)) {


### PR DESCRIPTION
The `crypto.webcrypto` is undefined in chrome background service.