### PR TITLE
Improve api error message

### DIFF
--- a/packages/web3/src/api/utils.ts
+++ b/packages/web3/src/api/utils.ts
@@ -20,9 +20,10 @@ import 'cross-fetch/polyfill'
 import { sleep } from '../utils'
 import { RateLimit } from 'async-sema'
 
-export function convertHttpResponse<T>(response: { data: T; error?: { detail: string } }): T {
+export function convertHttpResponse<T>(response: { status: number; data: T; error?: { detail: string } }): T {
   if (response.error) {
-    throw new Error(`[API Error] - ${response.error.detail}`)
+    const errorMessage = response.error.detail ?? `status code: ${response.status}`
+    throw new Error(`[API Error] - ${errorMessage}`)
   } else {
     return response.data
   }


### PR DESCRIPTION
Some endpoints of the full node on the testnet are not open. When accessing these endpoints, we will receive the message: `Error: [API Error] - undefined`, the error message we received after the change is `Error: [API ERROR] - status code: 404`.

And I think we can close [this issue](https://github.com/alephium/alephium-web3/issues/173), because the error message here is from the browser, not our SDK. I have tested it on both Firefox and Chrome, and Firefox's error message is more user-friendly than Chrome's.

Error message from firefox:

Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at https://wallet-v20.testnet.alephium.org/infos/node. (Reason: CORS header ‘Access-Control-Allow-Origin’ missing). Status code: 404.

Error message from chrome:

Access to fetch at 'https://wallet-v20.testnet.alephium.org/infos/node' from origin 'http://localhost:3000' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.