### PR TITLE
Fix the issue of could not find type declarations in vitejs

### DIFF
--- a/packages/web3-react/package.json
+++ b/packages/web3-react/package.json
@@ -9,7 +9,12 @@
     "url": "git+https://github.com/alephium/alephium-web3-react"
   },
   "type": "module",
-  "exports": "./build/index.es.js",
+  "exports": {
+    ".": {
+      "types": "./build/index.d.ts",
+      "import": "./build/index.es.js"
+    }
+  },
   "types": "./build/index.d.ts",
   "engines": {
     "node": ">=12.4"

--- a/packages/web3-react/rollup.config.dev.js
+++ b/packages/web3-react/rollup.config.dev.js
@@ -26,7 +26,7 @@ export default [
     external: ['react', 'react-dom', 'framer-motion'],
     output: [
       {
-        file: packageJson.exports,
+        file: packageJson.exports['.'].import,
         format: 'esm',
         sourcemap: false
       }

--- a/packages/web3-react/rollup.config.prod.js
+++ b/packages/web3-react/rollup.config.prod.js
@@ -25,7 +25,7 @@ export default [
     input: ['./src/index.ts'],
     external: ['react', 'react-dom', 'framer-motion'],
     output: {
-      file: packageJson.exports,
+      file: packageJson.exports['.'].import,
       format: 'esm',
       sourcemap: true
     },


### PR DESCRIPTION
I also tested other packages, the strange thing is that only `web3-react` has this issue.