### PR TITLE
Generate wallets for testing

### DIFF
--- a/packages/web3-test/src/index.ts
+++ b/packages/web3-test/src/index.ts
@@ -18,8 +18,17 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import 'cross-fetch/polyfill'
 
-import { addressFromContractId, isBase58, NodeProvider } from '@alephium/web3'
-import { NodeWallet } from '@alephium/web3-wallet'
+import {
+  addressFromContractId,
+  isBase58,
+  NodeProvider,
+  web3,
+  ONE_ALPH,
+  ALPH_TOKEN_ID,
+  DUST_AMOUNT,
+  Address
+} from '@alephium/web3'
+import { NodeWallet, PrivateKeyWallet } from '@alephium/web3-wallet'
 import { randomBytes } from 'crypto'
 
 export const testMnemonic =
@@ -65,6 +74,52 @@ export async function testNodeWallet(baseUrl = 'http://127.0.0.1:22973'): Promis
   const wallet = new NodeWallet(testWalletName, nodeProvider)
   await wallet.unlock(testPassword)
   return wallet
+}
+
+function tryGetDevnetNodeProvider(): NodeProvider {
+  try {
+    return web3.getCurrentNodeProvider()
+  } catch (err) {
+    const nodeProvider = new NodeProvider('http://127.0.0.1:22973')
+    web3.setCurrentNodeProvider(nodeProvider)
+    return nodeProvider
+  }
+}
+
+export async function getSigner(alphAmount = ONE_ALPH * 100n): Promise<PrivateKeyWallet> {
+  try {
+    const nodeProvider = tryGetDevnetNodeProvider()
+    const balances = await nodeProvider.addresses.getAddressesAddressBalance(testAddress)
+    const availableBalance = BigInt(balances.balance) - BigInt(balances.lockedBalance)
+    if (availableBalance < alphAmount) {
+      throw new Error('Not enough balance, please restart the devnet')
+    }
+    const rootWallet = new PrivateKeyWallet({ privateKey: testPrivateKey })
+    const wallet = PrivateKeyWallet.Random(rootWallet.group)
+    const destinations = [{ address: wallet.address, attoAlphAmount: alphAmount }]
+    await rootWallet.signAndSubmitTransferTx({ signerAddress: testAddress, destinations })
+    return wallet
+  } catch (_) {
+    throw new Error('Failed to get signer, please restart the devnet')
+  }
+}
+
+export async function getSigners(num: number, alphAmountPerSigner = ONE_ALPH * 100n): Promise<PrivateKeyWallet[]> {
+  try {
+    const promises = Array.from(Array(num).keys()).map(() => getSigner(alphAmountPerSigner))
+    return await Promise.all(promises)
+  } catch (_) {
+    throw new Error('Failed to get signers, please restart the devnet')
+  }
+}
+
+export async function transfer(from: PrivateKeyWallet, to: Address, tokenId: string, amount: bigint) {
+  const destination = {
+    address: to,
+    attoAlphAmount: tokenId === ALPH_TOKEN_ID ? amount : DUST_AMOUNT,
+    tokens: tokenId === ALPH_TOKEN_ID ? [] : [{ id: tokenId, amount }]
+  }
+  return await from.signAndSubmitTransferTx({ signerAddress: from.address, destinations: [destination] })
 }
 
 export async function expectAssertionError(p: Promise<unknown>, address: string, errorCode: number): Promise<void> {

--- a/packages/web3-wallet/src/node-wallet.test.ts
+++ b/packages/web3-wallet/src/node-wallet.test.ts
@@ -19,10 +19,12 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import { web3 } from '@alephium/web3'
 import { randomBytes } from 'crypto'
 import { NodeWallet } from './node-wallet'
+import { testNodeWallet } from '@alephium/web3-test'
 
 describe('node wallet', () => {
-  beforeAll(() => {
+  beforeAll(async () => {
     web3.setCurrentNodeProvider('http://127.0.0.1:22973', undefined, fetch)
+    await testNodeWallet()
   })
 
   it('should transfer (1)', async () => {

--- a/test/contract.test.ts
+++ b/test/contract.test.ts
@@ -34,9 +34,8 @@ import {
   DEFAULT_NODE_COMPILER_OPTIONS
 } from '../packages/web3'
 import { Contract, Project, Script } from '../packages/web3'
-import { testNodeWallet } from '../packages/web3-test'
 import { expectAssertionError, testAddress, randomContractAddress } from '../packages/web3-test'
-import { NodeWallet } from '@alephium/web3-wallet'
+import { PrivateKeyWallet } from '@alephium/web3-wallet'
 import { Greeter } from '../artifacts/ts/Greeter'
 import { GreeterMain, Main } from '../artifacts/ts/scripts'
 import { Sub, SubTypes } from '../artifacts/ts/Sub'
@@ -47,19 +46,19 @@ import { Debug } from '../artifacts/ts/Debug'
 import { getContractByCodeHash } from '../artifacts/ts/contracts'
 import { NFTTest, TokenTest } from '../artifacts/ts'
 import { randomBytes } from 'crypto'
+import { getSigner } from '@alephium/web3-test'
 
 describe('contract', function () {
-  let signer: NodeWallet
+  let signer: PrivateKeyWallet
   let signerAccount: Account
   let signerGroup: number
 
   beforeAll(async () => {
     web3.setCurrentNodeProvider('http://127.0.0.1:22973', undefined, fetch)
-    signer = await testNodeWallet()
-    signerAccount = await signer.getSelectedAccount()
+    signer = await getSigner()
+    signerAccount = signer.account
     signerGroup = signerAccount.group
 
-    expect(signerAccount.address).toEqual(testAddress)
     expect(signerGroup).toEqual(groupOfAddress(testAddress))
   })
 
@@ -186,7 +185,7 @@ describe('contract', function () {
       subContractPath,
       groupIndex
     )
-    const payer = testAddress
+    const payer = signer.address
     const testResult = await Add.tests.createSubContract({
       address: addAddress,
       group: groupIndex,
@@ -269,8 +268,8 @@ describe('contract', function () {
 
   it('should test assert!', async () => {
     await Project.build({ errorOnWarnings: false })
-    const testAddress = randomContractAddress()
-    expectAssertionError(Assert.tests.test({ address: testAddress }), testAddress, 3)
+    const contractAddress = randomContractAddress()
+    expectAssertionError(Assert.tests.test({ address: contractAddress }), contractAddress, 3)
   })
 
   it('should test enums and constants', async () => {

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -17,24 +17,24 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { Project, Contract, getContractEventsCurrentCount } from '../packages/web3'
-import { NodeWallet } from '../packages/web3-wallet'
 import { EventSubscribeOptions, sleep } from '../packages/web3'
 import { web3 } from '../packages/web3'
-import { testNodeWallet } from '../packages/web3-test'
 import { Sub } from '../artifacts/ts/Sub'
 import { Add, AddTypes, AddInstance } from '../artifacts/ts/Add'
 import { Main, DestroyAdd } from '../artifacts/ts/scripts'
 import { CreateContractEventAddress, DestroyContractEventAddress } from '../packages/web3'
 import { ContractCreatedEvent, subscribeContractCreatedEvent } from '../packages/web3'
 import { ContractDestroyedEvent, subscribeContractDestroyedEvent } from '../packages/web3'
+import { PrivateKeyWallet } from '@alephium/web3-wallet/dist/src/privatekey-wallet'
+import { getSigner } from '@alephium/web3-test'
 
 describe('events', function () {
-  let signer: NodeWallet
+  let signer: PrivateKeyWallet
   let eventCount: number
 
   beforeAll(async () => {
     web3.setCurrentNodeProvider('http://127.0.0.1:22973', undefined, fetch)
-    signer = await testNodeWallet()
+    signer = await getSigner()
     // ignore unused private function warnings
     await Project.build({ errorOnWarnings: false })
   })
@@ -43,7 +43,7 @@ describe('events', function () {
     eventCount = 0
   })
 
-  async function deployContract(signer: NodeWallet): Promise<AddInstance> {
+  async function deployContract(signer: PrivateKeyWallet): Promise<AddInstance> {
     const sub = await Sub.deploy(signer, { initialFields: { result: 0n } })
     return (await Add.deploy(signer, { initialFields: { sub: sub.contractInstance.contractId, result: 0n } }))
       .contractInstance

--- a/test/get-signer.test.ts
+++ b/test/get-signer.test.ts
@@ -1,0 +1,49 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { ONE_ALPH, web3 } from '@alephium/web3'
+import { getSigner, getSigners } from '@alephium/web3-test'
+
+describe('get signers', () => {
+  beforeAll(() => {
+    web3.setCurrentNodeProvider('http://127.0.0.1:22973', undefined, fetch)
+  })
+
+  it('get signer with group', async () => {
+    const nodeProvider = web3.getCurrentNodeProvider()
+    const signer0 = await getSigner(9n * ONE_ALPH)
+    expect(signer0.group).toEqual(0)
+    const balance0 = await nodeProvider.addresses.getAddressesAddressBalance(signer0.address)
+    expect(BigInt(balance0.balance)).toEqual(9n * ONE_ALPH)
+
+    const signer1 = await getSigner(10n * ONE_ALPH, 1)
+    expect(signer1.group).toEqual(1)
+    const balance1 = await nodeProvider.addresses.getAddressesAddressBalance(signer1.address)
+    expect(BigInt(balance1.balance)).toEqual(10n * ONE_ALPH)
+  })
+
+  it('get signers with group', async () => {
+    const signers0 = await getSigners(2, ONE_ALPH)
+    expect(signers0.length).toEqual(2)
+    signers0.forEach((signer) => expect(signer.group).toEqual(0))
+
+    const signers1 = await getSigners(3, ONE_ALPH, 1)
+    expect(signers1.length).toEqual(3)
+    signers1.forEach((signer) => expect(signer.group).toEqual(1))
+  })
+})

--- a/test/nft-collection.test.ts
+++ b/test/nft-collection.test.ts
@@ -27,18 +27,18 @@ import {
   addressFromContractId,
   hexToString
 } from '@alephium/web3'
-import { testNodeWallet } from '@alephium/web3-test'
-import { NodeWallet } from '@alephium/web3-wallet'
 import { NFTTest } from '../artifacts/ts/NFTTest'
 import { NFTCollectionTest, NFTCollectionTestInstance } from '../artifacts/ts/NFTCollectionTest'
 import { MintNFTTest } from '../artifacts/ts/scripts'
+import { getSigner } from '@alephium/web3-test'
+import { PrivateKeyWallet } from '@alephium/web3-wallet'
 
 describe('nft collection', function () {
-  let signer: NodeWallet
+  let signer: PrivateKeyWallet
 
   beforeAll(async () => {
     web3.setCurrentNodeProvider('http://127.0.0.1:22973', undefined, fetch)
-    signer = await testNodeWallet()
+    signer = await getSigner()
     await Project.build({ errorOnWarnings: false })
   })
 

--- a/test/node-provider.test.ts
+++ b/test/node-provider.test.ts
@@ -16,12 +16,15 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { testAddress, testWalletName } from '@alephium/web3-test'
+import { testAddress, testNodeWallet, testWalletName } from '@alephium/web3-test'
 import { web3, NodeProvider } from '../packages/web3/src'
 
 describe('node provider', () => {
   web3.setCurrentNodeProvider('http://127.0.0.1:22973')
   const nodeProvider = web3.getCurrentNodeProvider()
+  beforeAll(async () => {
+    await testNodeWallet()
+  })
 
   it('remote node provider should forward requests', async () => {
     const request = nodeProvider.request

--- a/test/token.test.ts
+++ b/test/token.test.ts
@@ -17,17 +17,17 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { web3, Project } from '@alephium/web3'
-import { testNodeWallet } from '@alephium/web3-test'
-import { NodeWallet } from '@alephium/web3-wallet'
 import { FakeTokenTest } from '../artifacts/ts'
 import { TokenTest } from '../artifacts/ts/TokenTest'
+import { PrivateKeyWallet } from '@alephium/web3-wallet'
+import { getSigner } from '@alephium/web3-test'
 
 describe('contract', function () {
-  let signer: NodeWallet
+  let signer: PrivateKeyWallet
 
   beforeAll(async () => {
     web3.setCurrentNodeProvider('http://127.0.0.1:22973')
-    signer = await testNodeWallet()
+    signer = await getSigner()
     await Project.build({ errorOnWarnings: false })
   })
 

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -19,20 +19,26 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import { subscribeToTxStatus } from '../packages/web3'
 import { Project } from '../packages/web3'
 import { node } from '../packages/web3'
-import { testNodeWallet } from '../packages/web3-test'
 import { SubscribeOptions, sleep } from '../packages/web3'
 import { web3 } from '../packages/web3'
 import { TxStatus } from '../packages/web3'
 import { PrivateKeyWallet } from '@alephium/web3-wallet'
 import { ONE_ALPH } from '../packages/web3/src'
 import { Add, Sub, Main } from '../artifacts/ts'
+import { getSigner } from '@alephium/web3-test'
 
 describe('transactions', function () {
-  it('should subscribe transaction status', async () => {
+  let signer: PrivateKeyWallet
+
+  beforeAll(async () => {
     web3.setCurrentNodeProvider('http://127.0.0.1:22973', undefined, fetch)
+    signer = await getSigner()
+    // ignore unused private function warnings
     await Project.build({ errorOnWarnings: false })
+  })
+
+  it('should subscribe transaction status', async () => {
     const sub = Project.contract('Sub')
-    const signer = await testNodeWallet()
     const txParams = await sub.txParamsForDeployment(signer, {
       initialFields: { result: 0n },
       initialTokenAmounts: []
@@ -77,29 +83,26 @@ describe('transactions', function () {
   }, 10000)
 
   it('should use Schnorr address', async () => {
-    web3.setCurrentNodeProvider('http://127.0.0.1:22973', undefined, fetch)
     const nodeProvider = web3.getCurrentNodeProvider()
+    const schnorrSigner = PrivateKeyWallet.Random(undefined, nodeProvider, 'bip340-schnorr')
 
-    await Project.build({ errorOnWarnings: false })
-    const genesisSigner = await testNodeWallet()
-    const signer = PrivateKeyWallet.Random(undefined, nodeProvider, 'bip340-schnorr')
-
-    const genesisAccount = await genesisSigner.getSelectedAccount()
-    await genesisSigner.signAndSubmitTransferTx({
+    const genesisAccount = await signer.getSelectedAccount()
+    await signer.signAndSubmitTransferTx({
       signerAddress: genesisAccount.address,
       signerKeyType: genesisAccount.keyType,
-      destinations: [{ address: signer.address, attoAlphAmount: 10n * ONE_ALPH }]
+      destinations: [{ address: schnorrSigner.address, attoAlphAmount: 10n * ONE_ALPH }]
     })
 
-    const subInstance = (await Sub.deploy(signer, { initialFields: { result: 0n } })).contractInstance
+    const subInstance = (await Sub.deploy(schnorrSigner, { initialFields: { result: 0n } })).contractInstance
     const subState = await subInstance.fetchState()
     expect(subState.fields.result).toBe(0n)
 
-    const addInstance = (await Add.deploy(signer, { initialFields: { sub: subInstance.contractId, result: 0n } }))
-      .contractInstance
+    const addInstance = (
+      await Add.deploy(schnorrSigner, { initialFields: { sub: subInstance.contractId, result: 0n } })
+    ).contractInstance
     expect((await addInstance.fetchState()).fields.result).toBe(0n)
 
-    await Main.execute(signer, { initialFields: { addContractId: addInstance.contractId } })
+    await Main.execute(schnorrSigner, { initialFields: { addContractId: addInstance.contractId } })
     expect((await addInstance.fetchState()).fields.result).toBe(3n)
   })
 })


### PR DESCRIPTION
The following is an example of a hardhat test:

```typescript
describe('test contract', () => {
  let wallet0: Wallet
  let wallet1: Wallet
  beforeAll(async () => {
    [wallet0, wallet1] = await getSigners()
  })
})
```

In hardhat, `getSigners` is used to load test wallets. When the user runs `hardhat test`, hardhat will start a devnet, and it will stop the devnet when the test is completed.

This is different from our usual practice, as we may keep the devnet running continuously, so it is still possible that ALPH has been exhausted, and users need to manually restart the devnet in this case.