### PR TITLE
Fix hexToString

### DIFF
--- a/packages/web3/src/utils/utils.test.ts
+++ b/packages/web3/src/utils/utils.test.ts
@@ -182,6 +182,8 @@ describe('utils', function () {
   it('should convert from string to hex and back', () => {
     expect(utils.stringToHex('Hello Alephium!')).toBe('48656c6c6f20416c65706869756d21')
     expect(utils.hexToString('48656c6c6f20416c65706869756d21')).toBe('Hello Alephium!')
+
+    expect(() => utils.hexToString('zzzz')).toThrow('Invalid hex string: zzzz')
   })
 
   it('should check hex string', () => {

--- a/packages/web3/src/utils/utils.ts
+++ b/packages/web3/src/utils/utils.ts
@@ -242,6 +242,9 @@ export function stringToHex(str: string): string {
 }
 
 export function hexToString(str: string): string {
+  if (!isHexString(str)) {
+    throw new Error(`Invalid hex string: ${str}`)
+  }
   return Buffer.from(str, 'hex').toString()
 }
 


### PR DESCRIPTION
Address #241 

The initial fields check works without problems, it does not throw an error because `hexToString` returns an empty string if the input is not a valid hex-string. For example:

1. `hexToString('zzzz') === ''`: it will not throw an error.
2. `hexToString('616c7068') === 'alph'`: it will throw an error.