### PR TITLE
Fix pops up twice when connecting with desktop wallet

### DIFF
--- a/packages/web3-react/src/hooks/useConnect.tsx
+++ b/packages/web3-react/src/hooks/useConnect.tsx
@@ -47,7 +47,9 @@ export function useConnect(options: ConnectOptions) {
       projectId: WALLET_CONNECT_PROJECT_ID,
       networkId: networkId,
       addressGroup: addressGroup,
-      onDisconnected: wcDisconnect
+      onDisconnected: () => {
+        return Promise.resolve()
+      }
     })
 
     wcProvider.on('displayUri', (uri) => {
@@ -67,14 +69,16 @@ export function useConnect(options: ConnectOptions) {
     }
 
     QRCodeModal.close()
-  }, [networkId, addressGroup, wcDisconnect, setAccount, setSignerProvider])
+  }, [networkId, addressGroup, setAccount, setSignerProvider])
 
   const desktopWalletConnect = useCallback(async () => {
     const wcProvider = await WalletConnectProvider.init({
       projectId: WALLET_CONNECT_PROJECT_ID,
       networkId: networkId,
       addressGroup: addressGroup,
-      onDisconnected: wcDisconnect
+      onDisconnected: () => {
+        return Promise.resolve()
+      }
     })
 
     wcProvider.on('displayUri', (uri) => {
@@ -92,7 +96,7 @@ export function useConnect(options: ConnectOptions) {
       console.log('wallet connect error')
       console.error(e)
     }
-  }, [networkId, addressGroup, wcDisconnect, setAccount, setSignerProvider])
+  }, [networkId, addressGroup, setAccount, setSignerProvider])
 
   const disconnectAlephium = useCallback(() => {
     getDefaultAlephiumWallet()


### PR DESCRIPTION
The `wcDisconnect` depends on `signerProvider`, and the `desktopWalletConnect` depends on `wcDisconnect`. After the wallet is connected, calling `useConnect` returns a new `desktopWalletConnect` instance, which leads to the pops up twice. In fact, `desktopWalletConnect` doesn't need to depend on `wcDisconnect`.

The reason this issue didn't exist in previous versions is that we only call the `connect` once in the `ConnectWithDesktopWallet` component(the dependencies list is empty): https://github.com/alephium/alephium-web3/blob/8cf20fee4c16091cf581518e9f411e31ec37955e/packages/web3-react/src/components/ConnectModal/ConnectWithDesktopWallet.tsx#L33