### PR TITLE
Support getting contract deployment result from other groups

### DIFF
--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -147,6 +147,8 @@ export interface Deployer {
 
   getDeployContractResult(name: string): DeployContractExecutionResult
   getRunScriptResult(name: string): RunScriptResult
+
+  getDeployContractResultFromGroup(name: string, group: number): DeployContractExecutionResult
 }
 
 export interface DeployFunction<Settings = unknown> {

--- a/packages/web3/src/contract/contract.ts
+++ b/packages/web3/src/contract/contract.ts
@@ -850,9 +850,9 @@ export class Contract extends Artifact {
       this.stdInterfaceId === undefined
         ? this.fieldsSig
         : {
-            names: this.fieldsSig.names.slice(-1),
-            types: this.fieldsSig.types.slice(-1),
-            isMutable: this.fieldsSig.isMutable.slice(-1)
+            names: this.fieldsSig.names.slice(0, -1),
+            types: this.fieldsSig.types.slice(0, -1),
+            isMutable: this.fieldsSig.isMutable.slice(0, -1)
           }
     return fields.names.reduce((acc, key, index) => {
       acc[`${key}`] = getDefaultValue(fields.types[`${index}`])

--- a/test/contract.test.ts
+++ b/test/contract.test.ts
@@ -214,6 +214,9 @@ describe('contract', function () {
     const result = await Greeter.deploy(signer, { initialFields })
     const state = await result.contractInstance.fetchState()
     expect(state.fields).toEqual(initialFields)
+
+    const tokenInitialFields = TokenTest.getInitialFieldsWithDefaultValues()
+    expect(tokenInitialFields).toEqual({ symbol: '', name: '', decimals: 0n, totalSupply: 0n })
   })
 
   function loadJson(fileName: string) {


### PR DESCRIPTION
Sometimes we need to retrieve contract results deployed on other groups, such as in the ANS contract, where the `PrimaryRegistrar` contract is deployed on group 0, and the `SecondaryRegistrar` deployed on other groups depends on the contract id of `PrimaryRegistrar`.