### PR TITLE
Fix NFT metadata attributes type

### DIFF
--- a/packages/web3/src/api/types.ts
+++ b/packages/web3/src/api/types.ts
@@ -343,12 +343,10 @@ export interface NFTTokenUriMetaData {
   name: string
   description?: string
   image: string
-  attributes?: [
-    {
-      trait_type: string
-      value: string | number | boolean
-    }
-  ]
+  attributes?: {
+    trait_type: string
+    value: string | number | boolean
+  }[]
 }
 
 export interface NFTCollectionUriMetaData {


### PR DESCRIPTION
I believe the `attributes` type is wrong. They way it's currently defined, it can only be an array of 1 element whos type is 
```ts
{
  trait_type: string
  value: string | number | boolean
}
```

Instead, what we want, is an array where EACH element is of that type.