### PR TITLE
Reposition and add file name to compilation error

### DIFF
--- a/packages/web3/src/contract/contract.ts
+++ b/packages/web3/src/contract/contract.ts
@@ -36,6 +36,7 @@ import {
   typeLength,
   getDefaultValue
 } from '../api'
+import { CompileProjectResult } from '../api/api-alephium'
 import {
   SignDeployContractTxParams,
   SignDeployContractTxResult,
@@ -63,6 +64,7 @@ import * as path from 'path'
 import { EventSubscribeOptions, EventSubscription, subscribeToEvents } from './events'
 import { ONE_ALPH } from '../constants'
 import * as blake from 'blakejs'
+import { parseError } from '../utils/error'
 
 const crypto = new WebCrypto()
 
@@ -190,6 +192,31 @@ type CodeInfo = {
   warnings: string[]
 }
 
+type SourceInfoIndexes = {
+  sourceInfo: SourceInfo
+  startIndex: number
+  endIndex: number
+}
+
+function findSourceInfoAtLineNumber(sources: SourceInfo[], line: number): SourceInfoIndexes | undefined {
+  let currentLine = 0
+  const sourceInfosWithLine: SourceInfoIndexes[] = sources.map((source) => {
+    const startIndex = currentLine + 1
+    currentLine += source.sourceCode.split('\n').length
+    const endIndex = currentLine
+    return { sourceInfo: source, startIndex: startIndex, endIndex: endIndex }
+  })
+
+  const sourceInfo = sourceInfosWithLine.find((sourceInfoWithLine) => {
+    return line >= sourceInfoWithLine.startIndex && line <= sourceInfoWithLine.endIndex
+  })
+
+  if (sourceInfo === undefined) {
+    return undefined
+  } else {
+    return sourceInfo
+  }
+}
 export class ProjectArtifact {
   static readonly artifactFileName = '.project.json'
 
@@ -431,6 +458,38 @@ export class Project {
     return contract.artifact
   }
 
+  private static async getCompileResult(
+    provider: NodeProvider,
+    compilerOptions: node.CompilerOptions,
+    sources: SourceInfo[]
+  ): Promise<CompileProjectResult> {
+    try {
+      const sourceStr = sources.map((f) => f.sourceCode).join('\n')
+      return await provider.contracts.postContractsCompileProject({
+        code: sourceStr,
+        compilerOptions: compilerOptions
+      })
+    } catch (error) {
+      if (!(error instanceof Error)) {
+        throw error
+      }
+
+      const parsed = parseError(error.message)
+      if (!parsed) {
+        throw error
+      }
+
+      const sourceInfo = findSourceInfoAtLineNumber(sources, parsed.lineStart)
+      if (!sourceInfo) {
+        throw error
+      }
+
+      const shiftIndex = parsed.lineStart - sourceInfo.startIndex + 1
+      const newError = parsed.reformat(shiftIndex, sourceInfo.sourceInfo.contractRelativePath)
+      throw new Error(newError)
+    }
+  }
+
   private static async compile(
     fullNodeVersion: string,
     provider: NodeProvider,
@@ -447,11 +506,8 @@ export class Project {
       }
       return acc
     }, [])
-    const sourceStr = removeDuplicates.map((f) => f.sourceCode).join('\n')
-    const result = await provider.contracts.postContractsCompileProject({
-      code: sourceStr,
-      compilerOptions: compilerOptions
-    })
+
+    const result = await Project.getCompileResult(provider, compilerOptions, removeDuplicates)
     const contracts = new Map<string, Compiled<Contract>>()
     const scripts = new Map<string, Compiled<Script>>()
     result.contracts.forEach((contractResult) => {

--- a/packages/web3/src/utils/error.test.ts
+++ b/packages/web3/src/utils/error.test.ts
@@ -1,0 +1,59 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { parseError } from './error'
+
+describe('error utils', function () {
+  it('parse and reformat error', () => {
+    function test(original: string, line: number, file: string, expected: string) {
+      const error = parseError(original)
+      if (error) {
+        expect(error.reformat(line, file)).toEqual(expected)
+      } else {
+        throw new Error(`cannoot parse error ${original}`)
+      }
+    }
+
+    const error = `-- error (256:3): Syntax error
+256 |  event add(a: u256, b: u256)
+    |  ^^^^^^^^^^
+    |  expected "}"
+    |-------------------------------------------------------------------------------------
+    |trace log: expected multicontract:1:1 / rawtxscript:2:1 / "}":3:3, found "event add("`
+
+    const expected = `nft/nft.ral (3:3): Syntax error
+3 |  event add(a: u256, b: u256)
+  |  ^^^^^^^^^^
+  |  expected "}"
+  |-------------------------------------------------------------------------------------
+  |trace log: expected multicontract:1:1 / rawtxscript:2:1 / "}":3:3, found "event add("`
+
+    const error2 = `-- error (7:3): Compilation error
+7 |  event Add1(b: U256, a: U256)
+  |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |  These events are defined multiple times: Add1, Add2`
+
+    const expected2 = `foo.ral (123456:3): Compilation error
+123456 |  event Add1(b: U256, a: U256)
+       |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       |  These events are defined multiple times: Add1, Add2`
+
+    test(error, 3, 'nft/nft.ral', expected)
+    test(error2, 123456, 'foo.ral', expected2)
+  })
+})

--- a/packages/web3/src/utils/error.ts
+++ b/packages/web3/src/utils/error.ts
@@ -1,0 +1,77 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+class CompilationError {
+  constructor(
+    public lineStart: number,
+    public column: number,
+    public errorType: string,
+    public line: number,
+    public codeLine: string,
+    public errorIndicator: string,
+    public message: string,
+    public additionalLine1?: string,
+    public additionalLine2?: string
+  ) {}
+
+  reformat(line: number, file: string): string {
+    const spaces = `${line}`.replace(/\d/g, ' ')
+    const newError = `${file} (${line}:${this.column}): ${this.errorType}
+${line} |${this.codeLine}
+${spaces} |${this.errorIndicator}
+${spaces} |${this.message}`
+
+    if (this.additionalLine1 && this.additionalLine2) {
+      return `${newError}\n${spaces} |${this.additionalLine1}\n${spaces} |${this.additionalLine2}`
+    } else {
+      return newError
+    }
+  }
+}
+
+const errorRegex = /error \((\d+):(\d+)\):\s*(.*)\n\s*(\d+)\s*\|(.*)\n.*\|(.*)\n\s*\|(.*)(?:\n\s*\|(.*)\n\s*\|(.*))?/
+
+export function parseError(error: string): CompilationError | undefined {
+  const match = error.match(errorRegex)
+
+  if (match) {
+    const lineStart = parseInt(match[1])
+    const column = parseInt(match[2])
+    const errorType = match[3]
+    const line = parseInt(match[4])
+    const codeLine = match[5]
+    const errorIndicator = match[6]
+    const message = match[7]
+    const additionalLine1 = match[8]
+    const additionalLine2 = match[9]
+
+    return new CompilationError(
+      lineStart,
+      column,
+      errorType,
+      line,
+      codeLine,
+      errorIndicator,
+      message,
+      additionalLine1,
+      additionalLine2
+    )
+  } else {
+    undefined
+  }
+}


### PR DESCRIPTION
This PR takes the error message coming from the node compilation and shift the index, as well as adding the file name to the error.
Received from node:
![image](https://github.com/alephium/alephium-web3/assets/2979182/af548dc5-4ab0-49f8-9d41-1380eb63103d)
after:
![image](https://github.com/alephium/alephium-web3/assets/2979182/4764fa78-34d0-4a90-bfa5-8fbd7f4b50a7)
