### PR TITLE
Fix expectAssertionError

### DIFF
--- a/.project.json
+++ b/.project.json
@@ -22,7 +22,7 @@
     },
     "Assert": {
       "sourceFile": "test/assert.ral",
-      "sourceCodeHash": "6e29a32037532fe7c415d6a8076626ee81767ff3162d3d2f34d08f7e0594a914",
+      "sourceCodeHash": "65f8387941a38e88ef555f5d0b4992dab390d97ff97b2473fdea45b8d58a74a5",
       "bytecodeDebugPatch": "",
       "codeHashDebug": "5bd05924fb9a23ea105df065a8c2dfa463b9ee53cc14a60320140d19dd6151ca",
       "warnings": [
@@ -273,6 +273,13 @@
     "TemplateArrayVar": {
       "sourceFile": "test/template_array_var.ral",
       "sourceCodeHash": "9d4585b01c450c8602f797f63995d1a734a260ea5579d68b81ba84272c9de235",
+      "bytecodeDebugPatch": "",
+      "codeHashDebug": "",
+      "warnings": []
+    },
+    "TestAssert": {
+      "sourceFile": "test/assert.ral",
+      "sourceCodeHash": "65f8387941a38e88ef555f5d0b4992dab390d97ff97b2473fdea45b8d58a74a5",
       "bytecodeDebugPatch": "",
       "codeHashDebug": "",
       "warnings": []

--- a/artifacts/test/TestAssert.ral.json
+++ b/artifacts/test/TestAssert.ral.json
@@ -1,0 +1,28 @@
+{
+  "version": "v2.11.0",
+  "name": "TestAssert",
+  "bytecodeTemplate": "010103000000040c0c{0}0100",
+  "fieldsSig": {
+    "names": [
+      "assert"
+    ],
+    "types": [
+      "Assert"
+    ],
+    "isMutable": [
+      false
+    ]
+  },
+  "functions": [
+    {
+      "name": "main",
+      "usePreapprovedAssets": true,
+      "useAssetsInContract": false,
+      "isPublic": true,
+      "paramNames": [],
+      "paramTypes": [],
+      "paramIsMutable": [],
+      "returnTypes": []
+    }
+  ]
+}

--- a/artifacts/ts/scripts.ts
+++ b/artifacts/ts/scripts.ts
@@ -18,6 +18,7 @@ import { default as MainScriptJson } from "../add/Main.ral.json";
 import { default as MintNFTTestScriptJson } from "../nft/MintNFTTest.ral.json";
 import { default as RemoveFromMapScriptJson } from "../test/RemoveFromMap.ral.json";
 import { default as TemplateArrayVarScriptJson } from "../test/TemplateArrayVar.ral.json";
+import { default as TestAssertScriptJson } from "../test/TestAssert.ral.json";
 import { default as UpdateMapValueScriptJson } from "../test/UpdateMapValue.ral.json";
 import { default as UpdateUserAccountScriptJson } from "../test/UpdateUserAccount.ral.json";
 import { default as WithdrawNFTCollectionTestScriptJson } from "../nft/WithdrawNFTCollectionTest.ral.json";
@@ -59,6 +60,10 @@ export const TemplateArrayVar = new ExecutableScript<{
   bytes: HexString;
   numbers1: [bigint, bigint, bigint];
 }>(Script.fromJson(TemplateArrayVarScriptJson, "", AllStructs));
+
+export const TestAssert = new ExecutableScript<{ assert: HexString }>(
+  Script.fromJson(TestAssertScriptJson, "", AllStructs)
+);
 
 export const UpdateMapValue = new ExecutableScript<{
   mapTest: HexString;

--- a/contracts/test/assert.ral
+++ b/contracts/test/assert.ral
@@ -23,3 +23,7 @@ Contract Assert() {
         assert!(1 == 2, Error)
     }
 }
+
+TxScript TestAssert(assert: Assert) {
+    assert.test()
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alephium/cli",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "description": "Alephium command line tool",
   "license": "GPL",
   "repository": {

--- a/packages/cli/templates/base/package.json
+++ b/packages/cli/templates/base/package.json
@@ -14,10 +14,10 @@
     "test": "jest -i --config ./jest-config.json"
   },
   "dependencies": {
-    "@alephium/cli": "^0.38.0",
-    "@alephium/web3": "^0.38.0",
-    "@alephium/web3-test": "^0.38.0",
-    "@alephium/web3-wallet": "^0.38.0"
+    "@alephium/cli": "^0.38.1",
+    "@alephium/web3": "^0.38.1",
+    "@alephium/web3-test": "^0.38.1",
+    "@alephium/web3-wallet": "^0.38.1"
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",

--- a/packages/cli/templates/react/package.json
+++ b/packages/cli/templates/react/package.json
@@ -9,7 +9,7 @@
     "@types/node": "^16.18.23",
     "@types/react": "^18.0.3",
     "@types/react-dom": "^18.0.0",
-    "@alephium/web3": "^0.38.0",
+    "@alephium/web3": "^0.38.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-scripts": "5.0.1",

--- a/packages/get-extension-wallet/package.json
+++ b/packages/get-extension-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alephium/get-extension-wallet",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/walletconnect/package.json
+++ b/packages/walletconnect/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alephium/walletconnect-provider",
   "description": "Alephium Provider for WalletConnect Protocol",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "author": "Alephium dev",
   "homepage": "https://github.com/alephium/walletconnect",
   "repository": {

--- a/packages/web3-react/package.json
+++ b/packages/web3-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alephium/web3-react",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "homepage": "https://github.com/alephium/alephium-web3-react",
   "license": "GPL",
   "description": "React components for Alephium Web3.",

--- a/packages/web3-test/package.json
+++ b/packages/web3-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alephium/web3-test",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "description": "Utility functions for Alephium test",
   "keywords": [
     "alephium",

--- a/packages/web3-test/src/test-wallet.ts
+++ b/packages/web3-test/src/test-wallet.ts
@@ -134,7 +134,7 @@ export async function transfer(from: PrivateKeyWallet, to: Address, tokenId: str
 export async function expectAssertionError(p: Promise<unknown>, address: string, errorCode: number): Promise<void> {
   expect(isBase58(address)).toEqual(true)
   await expect(p).rejects.toThrowError(
-    new RegExp(`VM execution error: Assertion Failed in Contract @ ${address}, Error Code: ${errorCode}`, 'mg')
+    new RegExp(`Assertion Failed in Contract @ ${address}, Error Code: ${errorCode}`, 'mg')
   )
 }
 

--- a/packages/web3-wallet/package.json
+++ b/packages/web3-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alephium/web3-wallet",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "description": "Simple wallets for Alephium",
   "keywords": [
     "alephium",

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alephium/web3",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "description": "A JS/TS library to interact with the Alephium platform",
   "license": "GPL",
   "main": "dist/src/index.js",

--- a/test/contract.test.ts
+++ b/test/contract.test.ts
@@ -32,7 +32,8 @@ import {
   groupOfAddress,
   ProjectArtifact,
   DEFAULT_NODE_COMPILER_OPTIONS,
-  DUST_AMOUNT
+  DUST_AMOUNT,
+  DEFAULT_GAS_AMOUNT
 } from '../packages/web3'
 import { Contract, Project, Script, getContractIdFromUnsignedTx } from '../packages/web3'
 import { expectAssertionError, testAddress, randomContractAddress, getSigner, mintToken } from '../packages/web3-test'
@@ -44,6 +45,7 @@ import {
   Main,
   RemoveFromMap,
   TemplateArrayVar,
+  TestAssert,
   UpdateUserAccount
 } from '../artifacts/ts/scripts'
 import { Sub, SubTypes } from '../artifacts/ts/Sub'
@@ -243,12 +245,12 @@ describe('contract', function () {
 
   it('should load source files by order', async () => {
     const sourceFiles = await Project['loadSourceFiles']('.', './contracts') // `loadSourceFiles` is a private method
-    expect(sourceFiles.length).toEqual(43)
+    expect(sourceFiles.length).toEqual(44)
     sourceFiles.slice(0, 23).forEach((c) => expect(c.type).toEqual(0)) // contracts
-    sourceFiles.slice(23, 33).forEach((s) => expect(s.type).toEqual(1)) // scripts
-    sourceFiles.slice(33, 35).forEach((i) => expect(i.type).toEqual(2)) // abstract class
-    sourceFiles.slice(35, 40).forEach((i) => expect(i.type).toEqual(3)) // interfaces
-    sourceFiles.slice(40).forEach((i) => expect(i.type).toEqual(4)) // structs
+    sourceFiles.slice(23, 34).forEach((s) => expect(s.type).toEqual(1)) // scripts
+    sourceFiles.slice(34, 36).forEach((i) => expect(i.type).toEqual(2)) // abstract class
+    sourceFiles.slice(36, 41).forEach((i) => expect(i.type).toEqual(3)) // interfaces
+    sourceFiles.slice(41).forEach((i) => expect(i.type).toEqual(4)) // structs
   })
 
   it('should load contract from json', () => {
@@ -299,6 +301,20 @@ describe('contract', function () {
     await Project.build({ errorOnWarnings: false })
     const contractAddress = randomContractAddress()
     expectAssertionError(Assert.tests.test({ address: contractAddress }), contractAddress, 3)
+
+    const assertDeployResult = await Assert.deploy(signer, { initialFields: {} })
+    const assertAddress = assertDeployResult.contractInstance.address
+
+    expectAssertionError(TestAssert.execute(signer, { initialFields: { assert: assertAddress } }), assertAddress, 3)
+
+    expectAssertionError(
+      TestAssert.execute(signer, {
+        initialFields: { assert: assertAddress },
+        gasAmount: DEFAULT_GAS_AMOUNT
+      }),
+      assertAddress,
+      3
+    )
   })
 
   it('should test enums and constants', async () => {


### PR DESCRIPTION
Fix `expectAssertionError` so it not only works for unit tests, but also for building tx (gas estimation) and submitting tx.

Error patterns for building tx (gas estimation):

```
"[API Error] - Execution error when estimating gas for tx script or contract: Assertion Failed in Contract @ zv46Fz8uNWDX5cJuReLFS6PykJd8axG7hjZaseU3ggYf, Error Code: 7
```

Error patters for submitting tx:

```
"[API Error] - Failed in validating tx 3ab6488d48ffeea377a783af18b0399e12055ad8824317ee1c33724ca07b5634 due to TxScriptExeFailed(Assertion Failed in Contract @ xB4eD1yH4kJ1NLLevsmdZBV2Fp9fbaQ5NFdjGL5jsw6P, Error Code: 7): 00040101010300000009b413c40de0b6b3a7640000a204040e0c14402033c6b4dd3e705fb131f3cffadc66d4db8e0254e681f376384ac1f00b234364000106800186a0c1174876e80001636c4e993ec9e80eed3def719e59d4909d9932d176ff01067c3d1f021518eec837864b4900037aa8dc31a406d82daffe05f52c1baf20347e7404cd462ad01ae02643de841e5601c5055dc320874beb0000001586f00a7b5761543ce54150c0362ff6dbb75fb20601f93b4485e38536405630000000000000000000000141cb8739ef478883e969fa87913eb3a1fb8491454e9865b486d12bd44658d28928aad069de057a3ef218766e61035adc40d7ceffde27284a8d4a1f0cac5c35bb00"
```

