### PR TITLE
Simple Transaction Method Call Without Explicit TxScript

### DIFF
--- a/.project.json
+++ b/.project.json
@@ -11,20 +11,22 @@
   "infos": {
     "Add": {
       "sourceFile": "add/add.ral",
-      "sourceCodeHash": "ff387b4feef2fd71654165255dd2eb872b8e7366f976419693f9124ed60a7ab2",
-      "bytecodeDebugPatch": "=10-2+50=2-2+70=2-2+79=63+77e010a=1+1646450726976617465=152",
-      "codeHashDebug": "9a4cf22e444db365cc62468b22db303401e6942409e193055e7f5f0318b389ca",
+      "sourceCodeHash": "b3a4696a12e8cbb2cb5fb1ebe18000beb0e67e9ff7194300b01f9cff8862701c",
+      "bytecodeDebugPatch": "=10-3+5=1-2=2-2+70=3+8=1+0a1=63+77e010a=1+1646450726976617465=232",
+      "codeHashDebug": "d43cf958572ed347683a41906781126fa8f76e9890a96a3d607d2ecff91b25ce",
       "warnings": [
         "Found unused variables in Add: add2.addS, add2.address, add2.array2",
         "The return values of the function \"Add.copyCreateSubContract\" are not used. If this is intentional, consider using anonymous variables to suppress this warning.",
+        "The return values of the function \"Add.copyCreateSubContract\" are not used. If this is intentional, consider using anonymous variables to suppress this warning.",
         "No external caller check for function \"Add.createSubContract\". Please use \"checkCaller!(...)\" in the function or its callees, or disable it with \"@using(checkExternalCaller = false)\".",
         "No external caller check for function \"Add.add\". Please use \"checkCaller!(...)\" in the function or its callees, or disable it with \"@using(checkExternalCaller = false)\".",
-        "No external caller check for function \"Add.add2\". Please use \"checkCaller!(...)\" in the function or its callees, or disable it with \"@using(checkExternalCaller = false)\"."
+        "No external caller check for function \"Add.add2\". Please use \"checkCaller!(...)\" in the function or its callees, or disable it with \"@using(checkExternalCaller = false)\".",
+        "No external caller check for function \"Add.createSubContractAndTransfer\". Please use \"checkCaller!(...)\" in the function or its callees, or disable it with \"@using(checkExternalCaller = false)\"."
       ]
     },
     "AddMain": {
       "sourceFile": "add/add.ral",
-      "sourceCodeHash": "ff387b4feef2fd71654165255dd2eb872b8e7366f976419693f9124ed60a7ab2",
+      "sourceCodeHash": "b3a4696a12e8cbb2cb5fb1ebe18000beb0e67e9ff7194300b01f9cff8862701c",
       "bytecodeDebugPatch": "",
       "codeHashDebug": "",
       "warnings": [
@@ -33,14 +35,14 @@
     },
     "AddStruct1": {
       "sourceFile": "add/add.ral",
-      "sourceCodeHash": "ff387b4feef2fd71654165255dd2eb872b8e7366f976419693f9124ed60a7ab2",
+      "sourceCodeHash": "b3a4696a12e8cbb2cb5fb1ebe18000beb0e67e9ff7194300b01f9cff8862701c",
       "bytecodeDebugPatch": "",
       "codeHashDebug": "",
       "warnings": []
     },
     "AddStruct2": {
       "sourceFile": "add/add.ral",
-      "sourceCodeHash": "ff387b4feef2fd71654165255dd2eb872b8e7366f976419693f9124ed60a7ab2",
+      "sourceCodeHash": "b3a4696a12e8cbb2cb5fb1ebe18000beb0e67e9ff7194300b01f9cff8862701c",
       "bytecodeDebugPatch": "",
       "codeHashDebug": "",
       "warnings": []

--- a/.project.json
+++ b/.project.json
@@ -11,23 +11,39 @@
   "infos": {
     "Add": {
       "sourceFile": "add/add.ral",
-      "sourceCodeHash": "1aefef4f21ebee078768df8158bd43d5008e640e443f9b41f0cdbfc8e43eccdd",
-      "bytecodeDebugPatch": "=8+4=1-1=2-1=1+3=2-2+6c=37+77e010a=1+1646450726976617465=152",
-      "codeHashDebug": "6d87d293224fce4601a8e315e6a384aca46fdd1adab1402ffae8cc454b94a66e",
+      "sourceCodeHash": "ff387b4feef2fd71654165255dd2eb872b8e7366f976419693f9124ed60a7ab2",
+      "bytecodeDebugPatch": "=10-2+50=2-2+70=2-2+79=63+77e010a=1+1646450726976617465=152",
+      "codeHashDebug": "9a4cf22e444db365cc62468b22db303401e6942409e193055e7f5f0318b389ca",
       "warnings": [
+        "Found unused variables in Add: add2.addS, add2.address, add2.array2",
         "The return values of the function \"Add.copyCreateSubContract\" are not used. If this is intentional, consider using anonymous variables to suppress this warning.",
         "No external caller check for function \"Add.createSubContract\". Please use \"checkCaller!(...)\" in the function or its callees, or disable it with \"@using(checkExternalCaller = false)\".",
-        "No external caller check for function \"Add.add\". Please use \"checkCaller!(...)\" in the function or its callees, or disable it with \"@using(checkExternalCaller = false)\"."
+        "No external caller check for function \"Add.add\". Please use \"checkCaller!(...)\" in the function or its callees, or disable it with \"@using(checkExternalCaller = false)\".",
+        "No external caller check for function \"Add.add2\". Please use \"checkCaller!(...)\" in the function or its callees, or disable it with \"@using(checkExternalCaller = false)\"."
       ]
     },
     "AddMain": {
       "sourceFile": "add/add.ral",
-      "sourceCodeHash": "1aefef4f21ebee078768df8158bd43d5008e640e443f9b41f0cdbfc8e43eccdd",
+      "sourceCodeHash": "ff387b4feef2fd71654165255dd2eb872b8e7366f976419693f9124ed60a7ab2",
       "bytecodeDebugPatch": "",
       "codeHashDebug": "",
       "warnings": [
         "The return values of the function \"Add.add\" are not used. If this is intentional, consider using anonymous variables to suppress this warning."
       ]
+    },
+    "AddStruct1": {
+      "sourceFile": "add/add.ral",
+      "sourceCodeHash": "ff387b4feef2fd71654165255dd2eb872b8e7366f976419693f9124ed60a7ab2",
+      "bytecodeDebugPatch": "",
+      "codeHashDebug": "",
+      "warnings": []
+    },
+    "AddStruct2": {
+      "sourceFile": "add/add.ral",
+      "sourceCodeHash": "ff387b4feef2fd71654165255dd2eb872b8e7366f976419693f9124ed60a7ab2",
+      "bytecodeDebugPatch": "",
+      "codeHashDebug": "",
+      "warnings": []
     },
     "Assert": {
       "sourceFile": "test/assert.ral",

--- a/.project.json
+++ b/.project.json
@@ -11,13 +11,22 @@
   "infos": {
     "Add": {
       "sourceFile": "add/add.ral",
-      "sourceCodeHash": "95b2d5b3755f9a00b616a8beaccf7b42da269ae57a25ec825c333395cd2a23bc",
+      "sourceCodeHash": "1aefef4f21ebee078768df8158bd43d5008e640e443f9b41f0cdbfc8e43eccdd",
       "bytecodeDebugPatch": "=8+4=1-1=2-1=1+3=2-2+6c=37+77e010a=1+1646450726976617465=152",
       "codeHashDebug": "6d87d293224fce4601a8e315e6a384aca46fdd1adab1402ffae8cc454b94a66e",
       "warnings": [
         "The return values of the function \"Add.copyCreateSubContract\" are not used. If this is intentional, consider using anonymous variables to suppress this warning.",
         "No external caller check for function \"Add.createSubContract\". Please use \"checkCaller!(...)\" in the function or its callees, or disable it with \"@using(checkExternalCaller = false)\".",
         "No external caller check for function \"Add.add\". Please use \"checkCaller!(...)\" in the function or its callees, or disable it with \"@using(checkExternalCaller = false)\"."
+      ]
+    },
+    "AddMain": {
+      "sourceFile": "add/add.ral",
+      "sourceCodeHash": "1aefef4f21ebee078768df8158bd43d5008e640e443f9b41f0cdbfc8e43eccdd",
+      "bytecodeDebugPatch": "",
+      "codeHashDebug": "",
+      "warnings": [
+        "The return values of the function \"Add.add\" are not used. If this is intentional, consider using anonymous variables to suppress this warning."
       ]
     },
     "Assert": {
@@ -170,15 +179,6 @@
       "bytecodeDebugPatch": "",
       "codeHashDebug": "",
       "warnings": []
-    },
-    "Main": {
-      "sourceFile": "add/add.ral",
-      "sourceCodeHash": "95b2d5b3755f9a00b616a8beaccf7b42da269ae57a25ec825c333395cd2a23bc",
-      "bytecodeDebugPatch": "",
-      "codeHashDebug": "",
-      "warnings": [
-        "The return values of the function \"Add.add\" are not used. If this is intentional, consider using anonymous variables to suppress this warning."
-      ]
     },
     "MapTest": {
       "sourceFile": "test/map.ral",

--- a/artifacts/add/Add.ral.json
+++ b/artifacts/add/Add.ral.json
@@ -1,8 +1,8 @@
 {
   "version": "v2.11.0",
   "name": "Add",
-  "bytecode": "02040d40364056405f0100020402041600160100010200000202021605160016015f06160016015fa00016002a16012aa100a000160016010e0dce000100020103040600101300641600130164170517041603d1a21601160216041605c1180102010100021600b0",
-  "codeHash": "97dbb799a710b8cf8dd878e3892333657c26020014bd2f0099850a26bd39668a",
+  "bytecode": "02050d1a40434063406c0100021002041600160100020201000c0c02041600160100020200000202021605160016015f06160016015fa00016002a16012aa100a000160016010e0dce000100020103040600101300641600130164170517041603d1a21601160216041605c1180102010100021600b0",
+  "codeHash": "cb9bcf12cd42167de9cd08cbb974d03263bf8fd12fae62340a72029f35497b04",
   "fieldsSig": {
     "names": [
       "sub",
@@ -54,6 +54,33 @@
         "[U256;2]"
       ],
       "paramIsMutable": [
+        false
+      ],
+      "returnTypes": [
+        "[U256;2]"
+      ]
+    },
+    {
+      "name": "add2",
+      "usePreapprovedAssets": false,
+      "useAssetsInContract": false,
+      "isPublic": true,
+      "paramNames": [
+        "array1",
+        "address",
+        "array2",
+        "addS"
+      ],
+      "paramTypes": [
+        "[U256;2]",
+        "Address",
+        "[U256;2]",
+        "AddStruct1"
+      ],
+      "paramIsMutable": [
+        false,
+        false,
+        false,
         false
       ],
       "returnTypes": [

--- a/artifacts/add/Add.ral.json
+++ b/artifacts/add/Add.ral.json
@@ -1,8 +1,8 @@
 {
   "version": "v2.11.0",
   "name": "Add",
-  "bytecode": "02050d1a40434063406c0100021002041600160100020201000c0c02041600160100020200000202021605160016015f06160016015fa00016002a16012aa100a000160016010e0dce000100020103040600101300641600130164170517041603d1a21601160216041605c1180102010100021600b0",
-  "codeHash": "cb9bcf12cd42167de9cd08cbb974d03263bf8fd12fae62340a72029f35497b04",
+  "bytecode": "02060d1a40434063408b40940100021002041600160100020201000c0c02041600160100020200000202021605160016015f06160016015fa00016002a16012aa100a000160016010e0dce000100020103040c00101300641600130164170517041603d1a21601160216041605c118010104060014130064160013016417051704160316021340c8ac1603d1a21601160216041605c1180102010100021600b0",
+  "codeHash": "6fa2e126a8361f8bfba25ce9c0dc57924427ec46bb99720ddab30c1105123ec5",
   "fieldsSig": {
     "names": [
       "sub",
@@ -109,6 +109,31 @@
       "name": "createSubContract",
       "usePreapprovedAssets": true,
       "useAssetsInContract": false,
+      "isPublic": true,
+      "paramNames": [
+        "a",
+        "path",
+        "subContractId",
+        "payer"
+      ],
+      "paramTypes": [
+        "U256",
+        "ByteVec",
+        "ByteVec",
+        "Address"
+      ],
+      "paramIsMutable": [
+        false,
+        false,
+        false,
+        false
+      ],
+      "returnTypes": []
+    },
+    {
+      "name": "createSubContractAndTransfer",
+      "usePreapprovedAssets": true,
+      "useAssetsInContract": true,
       "isPublic": true,
       "paramNames": [
         "a",

--- a/artifacts/add/AddMain.ral.json
+++ b/artifacts/add/AddMain.ral.json
@@ -1,15 +1,18 @@
 {
   "version": "v2.11.0",
-  "name": "Main",
-  "bytecodeTemplate": "0101030001000a{0}17000e0d0e0e160001001818",
+  "name": "AddMain",
+  "bytecodeTemplate": "0101030002000c{1}{2}17011700160016010e0e{0}01001818",
   "fieldsSig": {
     "names": [
-      "addContractId"
+      "add",
+      "array"
     ],
     "types": [
-      "ByteVec"
+      "Add",
+      "[U256;2]"
     ],
     "isMutable": [
+      false,
       false
     ]
   },

--- a/artifacts/add/DestroyAdd.ral.json
+++ b/artifacts/add/DestroyAdd.ral.json
@@ -1,7 +1,7 @@
 {
   "version": "v2.11.0",
   "name": "DestroyAdd",
-  "bytecodeTemplate": "01010300000005{1}0d0c{0}0103",
+  "bytecodeTemplate": "01010300000005{1}0d0c{0}0104",
   "fieldsSig": {
     "names": [
       "add",

--- a/artifacts/add/DestroyAdd.ral.json
+++ b/artifacts/add/DestroyAdd.ral.json
@@ -1,7 +1,7 @@
 {
   "version": "v2.11.0",
   "name": "DestroyAdd",
-  "bytecodeTemplate": "01010300000005{1}0d0c{0}0104",
+  "bytecodeTemplate": "01010300000005{1}0d0c{0}0105",
   "fieldsSig": {
     "names": [
       "add",

--- a/artifacts/structs.ral.json
+++ b/artifacts/structs.ral.json
@@ -1,5 +1,35 @@
 [
   {
+    "name": "AddStruct1",
+    "fieldNames": [
+      "a",
+      "b"
+    ],
+    "fieldTypes": [
+      "U256",
+      "[AddStruct2;2]"
+    ],
+    "isMutable": [
+      false,
+      false
+    ]
+  },
+  {
+    "name": "AddStruct2",
+    "fieldNames": [
+      "a",
+      "b"
+    ],
+    "fieldTypes": [
+      "U256",
+      "[U256;2]"
+    ],
+    "isMutable": [
+      false,
+      false
+    ]
+  },
+  {
     "name": "MapValue",
     "fieldNames": [
       "id",

--- a/artifacts/ts/Add.ts
+++ b/artifacts/ts/Add.ts
@@ -31,7 +31,14 @@ import {
 } from "@alephium/web3";
 import { default as AddContractJson } from "../add/Add.ral.json";
 import { getContractByCodeHash } from "./contracts";
-import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
+import {
+  AddStruct1,
+  AddStruct2,
+  Balances,
+  MapValue,
+  TokenBalance,
+  AllStructs,
+} from "./types";
 
 // Custom types for the contract
 export namespace AddTypes {
@@ -48,6 +55,15 @@ export namespace AddTypes {
   export interface CallMethodTable {
     add: {
       params: CallContractParams<{ array: [bigint, bigint] }>;
+      result: CallContractResult<[bigint, bigint]>;
+    };
+    add2: {
+      params: CallContractParams<{
+        array1: [bigint, bigint];
+        address: Address;
+        array2: [bigint, bigint];
+        addS: AddStruct1;
+      }>;
       result: CallContractResult<[bigint, bigint]>;
     };
     createSubContract: {
@@ -80,6 +96,15 @@ export namespace AddTypes {
   export interface SignExecuteMethodTable {
     add: {
       params: SignExecuteContractMethodParams<{ array: [bigint, bigint] }>;
+      result: SignExecuteScriptTxResult;
+    };
+    add2: {
+      params: SignExecuteContractMethodParams<{
+        array1: [bigint, bigint];
+        address: Address;
+        array2: [bigint, bigint];
+        addS: AddStruct1;
+      }>;
       result: SignExecuteScriptTxResult;
     };
     createSubContract: {
@@ -122,6 +147,19 @@ class Factory extends ContractFactory<AddInstance, AddTypes.Fields> {
     ): Promise<TestContractResultWithoutMaps<[bigint, bigint]>> => {
       return testMethod(this, "add", params);
     },
+    add2: async (
+      params: TestContractParamsWithoutMaps<
+        AddTypes.Fields,
+        {
+          array1: [bigint, bigint];
+          address: Address;
+          array2: [bigint, bigint];
+          addS: AddStruct1;
+        }
+      >
+    ): Promise<TestContractResultWithoutMaps<[bigint, bigint]>> => {
+      return testMethod(this, "add2", params);
+    },
     addPrivate: async (
       params: TestContractParamsWithoutMaps<
         AddTypes.Fields,
@@ -153,8 +191,8 @@ class Factory extends ContractFactory<AddInstance, AddTypes.Fields> {
 export const Add = new Factory(
   Contract.fromJson(
     AddContractJson,
-    "=8+4=1-1=2-1=1+3=2-2+6c=37+77e010a=1+1646450726976617465=152",
-    "6d87d293224fce4601a8e315e6a384aca46fdd1adab1402ffae8cc454b94a66e",
+    "=10-2+50=2-2+70=2-2+79=63+77e010a=1+1646450726976617465=152",
+    "9a4cf22e444db365cc62468b22db303401e6942409e193055e7f5f0318b389ca",
     AllStructs
   )
 );
@@ -212,6 +250,11 @@ export class AddInstance extends ContractInstance {
     ): Promise<AddTypes.CallMethodResult<"add">> => {
       return callMethod(Add, this, "add", params, getContractByCodeHash);
     },
+    add2: async (
+      params: AddTypes.CallMethodParams<"add2">
+    ): Promise<AddTypes.CallMethodResult<"add2">> => {
+      return callMethod(Add, this, "add2", params, getContractByCodeHash);
+    },
     createSubContract: async (
       params: AddTypes.CallMethodParams<"createSubContract">
     ): Promise<AddTypes.CallMethodResult<"createSubContract">> => {
@@ -237,6 +280,11 @@ export class AddInstance extends ContractInstance {
       params: AddTypes.SignExecuteMethodParams<"add">
     ): Promise<AddTypes.SignExecuteMethodResult<"add">> => {
       return signExecuteMethod(Add, this, "add", params);
+    },
+    add2: async (
+      params: AddTypes.SignExecuteMethodParams<"add2">
+    ): Promise<AddTypes.SignExecuteMethodResult<"add2">> => {
+      return signExecuteMethod(Add, this, "add2", params);
     },
     createSubContract: async (
       params: AddTypes.SignExecuteMethodParams<"createSubContract">

--- a/artifacts/ts/Add.ts
+++ b/artifacts/ts/Add.ts
@@ -25,6 +25,9 @@ import {
   getContractEventsCurrentCount,
   TestContractParamsWithoutMaps,
   TestContractResultWithoutMaps,
+  SignExecuteContractMethodParams,
+  SignExecuteScriptTxResult,
+  signExecuteMethod,
 } from "@alephium/web3";
 import { default as AddContractJson } from "../add/Add.ral.json";
 import { getContractByCodeHash } from "./contracts";
@@ -60,6 +63,26 @@ export namespace AddTypes {
       ? CallMethodTable[MaybeName]["result"]
       : undefined;
   };
+
+  export interface SignExecuteMethodTable {
+    createSubContract: {
+      params: SignExecuteContractMethodParams<{
+        a: bigint;
+        path: HexString;
+        subContractId: HexString;
+        payer: Address;
+      }>;
+      result: SignExecuteScriptTxResult;
+    };
+    destroy: {
+      params: SignExecuteContractMethodParams<{ caller: Address }>;
+      result: SignExecuteScriptTxResult;
+    };
+  }
+  export type SignExecuteMethodParams<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["params"];
+  export type SignExecuteMethodResult<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["result"];
 }
 
 class Factory extends ContractFactory<AddInstance, AddTypes.Fields> {
@@ -171,6 +194,16 @@ export class AddInstance extends ContractInstance {
       params: AddTypes.CallMethodParams<"add">
     ): Promise<AddTypes.CallMethodResult<"add">> => {
       return callMethod(Add, this, "add", params, getContractByCodeHash);
+    },
+    createSubContract: async (
+      params: AddTypes.SignExecuteMethodParams<"createSubContract">
+    ): Promise<AddTypes.SignExecuteMethodResult<"createSubContract">> => {
+      return signExecuteMethod(Add, this, "createSubContract", params);
+    },
+    destroy: async (
+      params: AddTypes.SignExecuteMethodParams<"destroy">
+    ): Promise<AddTypes.SignExecuteMethodResult<"destroy">> => {
+      return signExecuteMethod(Add, this, "destroy", params);
     },
   };
 

--- a/artifacts/ts/Add.ts
+++ b/artifacts/ts/Add.ts
@@ -50,6 +50,19 @@ export namespace AddTypes {
       params: CallContractParams<{ array: [bigint, bigint] }>;
       result: CallContractResult<[bigint, bigint]>;
     };
+    createSubContract: {
+      params: CallContractParams<{
+        a: bigint;
+        path: HexString;
+        subContractId: HexString;
+        payer: Address;
+      }>;
+      result: CallContractResult<null>;
+    };
+    destroy: {
+      params: CallContractParams<{ caller: Address }>;
+      result: CallContractResult<null>;
+    };
   }
   export type CallMethodParams<T extends keyof CallMethodTable> =
     CallMethodTable[T]["params"];
@@ -65,6 +78,10 @@ export namespace AddTypes {
   };
 
   export interface SignExecuteMethodTable {
+    add: {
+      params: SignExecuteContractMethodParams<{ array: [bigint, bigint] }>;
+      result: SignExecuteScriptTxResult;
+    };
     createSubContract: {
       params: SignExecuteContractMethodParams<{
         a: bigint;
@@ -194,6 +211,32 @@ export class AddInstance extends ContractInstance {
       params: AddTypes.CallMethodParams<"add">
     ): Promise<AddTypes.CallMethodResult<"add">> => {
       return callMethod(Add, this, "add", params, getContractByCodeHash);
+    },
+    createSubContract: async (
+      params: AddTypes.CallMethodParams<"createSubContract">
+    ): Promise<AddTypes.CallMethodResult<"createSubContract">> => {
+      return callMethod(
+        Add,
+        this,
+        "createSubContract",
+        params,
+        getContractByCodeHash
+      );
+    },
+    destroy: async (
+      params: AddTypes.CallMethodParams<"destroy">
+    ): Promise<AddTypes.CallMethodResult<"destroy">> => {
+      return callMethod(Add, this, "destroy", params, getContractByCodeHash);
+    },
+  };
+
+  call = this.methods;
+
+  transaction = {
+    add: async (
+      params: AddTypes.SignExecuteMethodParams<"add">
+    ): Promise<AddTypes.SignExecuteMethodResult<"add">> => {
+      return signExecuteMethod(Add, this, "add", params);
     },
     createSubContract: async (
       params: AddTypes.SignExecuteMethodParams<"createSubContract">

--- a/artifacts/ts/Add.ts
+++ b/artifacts/ts/Add.ts
@@ -75,6 +75,15 @@ export namespace AddTypes {
       }>;
       result: CallContractResult<null>;
     };
+    createSubContractAndTransfer: {
+      params: CallContractParams<{
+        a: bigint;
+        path: HexString;
+        subContractId: HexString;
+        payer: Address;
+      }>;
+      result: CallContractResult<null>;
+    };
     destroy: {
       params: CallContractParams<{ caller: Address }>;
       result: CallContractResult<null>;
@@ -108,6 +117,15 @@ export namespace AddTypes {
       result: SignExecuteScriptTxResult;
     };
     createSubContract: {
+      params: SignExecuteContractMethodParams<{
+        a: bigint;
+        path: HexString;
+        subContractId: HexString;
+        payer: Address;
+      }>;
+      result: SignExecuteScriptTxResult;
+    };
+    createSubContractAndTransfer: {
       params: SignExecuteContractMethodParams<{
         a: bigint;
         path: HexString;
@@ -176,6 +194,14 @@ class Factory extends ContractFactory<AddInstance, AddTypes.Fields> {
     ): Promise<TestContractResultWithoutMaps<null>> => {
       return testMethod(this, "createSubContract", params);
     },
+    createSubContractAndTransfer: async (
+      params: TestContractParamsWithoutMaps<
+        AddTypes.Fields,
+        { a: bigint; path: HexString; subContractId: HexString; payer: Address }
+      >
+    ): Promise<TestContractResultWithoutMaps<null>> => {
+      return testMethod(this, "createSubContractAndTransfer", params);
+    },
     destroy: async (
       params: TestContractParamsWithoutMaps<
         AddTypes.Fields,
@@ -191,8 +217,8 @@ class Factory extends ContractFactory<AddInstance, AddTypes.Fields> {
 export const Add = new Factory(
   Contract.fromJson(
     AddContractJson,
-    "=10-2+50=2-2+70=2-2+79=63+77e010a=1+1646450726976617465=152",
-    "9a4cf22e444db365cc62468b22db303401e6942409e193055e7f5f0318b389ca",
+    "=10-3+5=1-2=2-2+70=3+8=1+0a1=63+77e010a=1+1646450726976617465=232",
+    "d43cf958572ed347683a41906781126fa8f76e9890a96a3d607d2ecff91b25ce",
     AllStructs
   )
 );
@@ -266,6 +292,17 @@ export class AddInstance extends ContractInstance {
         getContractByCodeHash
       );
     },
+    createSubContractAndTransfer: async (
+      params: AddTypes.CallMethodParams<"createSubContractAndTransfer">
+    ): Promise<AddTypes.CallMethodResult<"createSubContractAndTransfer">> => {
+      return callMethod(
+        Add,
+        this,
+        "createSubContractAndTransfer",
+        params,
+        getContractByCodeHash
+      );
+    },
     destroy: async (
       params: AddTypes.CallMethodParams<"destroy">
     ): Promise<AddTypes.CallMethodResult<"destroy">> => {
@@ -290,6 +327,18 @@ export class AddInstance extends ContractInstance {
       params: AddTypes.SignExecuteMethodParams<"createSubContract">
     ): Promise<AddTypes.SignExecuteMethodResult<"createSubContract">> => {
       return signExecuteMethod(Add, this, "createSubContract", params);
+    },
+    createSubContractAndTransfer: async (
+      params: AddTypes.SignExecuteMethodParams<"createSubContractAndTransfer">
+    ): Promise<
+      AddTypes.SignExecuteMethodResult<"createSubContractAndTransfer">
+    > => {
+      return signExecuteMethod(
+        Add,
+        this,
+        "createSubContractAndTransfer",
+        params
+      );
     },
     destroy: async (
       params: AddTypes.SignExecuteMethodParams<"destroy">

--- a/artifacts/ts/Assert.ts
+++ b/artifacts/ts/Assert.ts
@@ -31,7 +31,14 @@ import {
 } from "@alephium/web3";
 import { default as AssertContractJson } from "../test/Assert.ral.json";
 import { getContractByCodeHash } from "./contracts";
-import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
+import {
+  AddStruct1,
+  AddStruct2,
+  Balances,
+  MapValue,
+  TokenBalance,
+  AllStructs,
+} from "./types";
 
 // Custom types for the contract
 export namespace AssertTypes {

--- a/artifacts/ts/Assert.ts
+++ b/artifacts/ts/Assert.ts
@@ -37,6 +37,25 @@ import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
 export namespace AssertTypes {
   export type State = Omit<ContractState<any>, "fields">;
 
+  export interface CallMethodTable {
+    test: {
+      params: Omit<CallContractParams<{}>, "args">;
+      result: CallContractResult<null>;
+    };
+  }
+  export type CallMethodParams<T extends keyof CallMethodTable> =
+    CallMethodTable[T]["params"];
+  export type CallMethodResult<T extends keyof CallMethodTable> =
+    CallMethodTable[T]["result"];
+  export type MultiCallParams = Partial<{
+    [Name in keyof CallMethodTable]: CallMethodTable[Name]["params"];
+  }>;
+  export type MultiCallResults<T extends MultiCallParams> = {
+    [MaybeName in keyof T]: MaybeName extends keyof CallMethodTable
+      ? CallMethodTable[MaybeName]["result"]
+      : undefined;
+  };
+
   export interface SignExecuteMethodTable {
     test: {
       params: Omit<SignExecuteContractMethodParams<{}>, "args">;
@@ -100,6 +119,22 @@ export class AssertInstance extends ContractInstance {
   }
 
   methods = {
+    test: async (
+      params?: AssertTypes.CallMethodParams<"test">
+    ): Promise<AssertTypes.CallMethodResult<"test">> => {
+      return callMethod(
+        Assert,
+        this,
+        "test",
+        params === undefined ? {} : params,
+        getContractByCodeHash
+      );
+    },
+  };
+
+  call = this.methods;
+
+  transaction = {
     test: async (
       params: AssertTypes.SignExecuteMethodParams<"test">
     ): Promise<AssertTypes.SignExecuteMethodResult<"test">> => {

--- a/artifacts/ts/Assert.ts
+++ b/artifacts/ts/Assert.ts
@@ -25,6 +25,9 @@ import {
   getContractEventsCurrentCount,
   TestContractParamsWithoutMaps,
   TestContractResultWithoutMaps,
+  SignExecuteContractMethodParams,
+  SignExecuteScriptTxResult,
+  signExecuteMethod,
 } from "@alephium/web3";
 import { default as AssertContractJson } from "../test/Assert.ral.json";
 import { getContractByCodeHash } from "./contracts";
@@ -33,6 +36,17 @@ import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
 // Custom types for the contract
 export namespace AssertTypes {
   export type State = Omit<ContractState<any>, "fields">;
+
+  export interface SignExecuteMethodTable {
+    test: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+  }
+  export type SignExecuteMethodParams<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["params"];
+  export type SignExecuteMethodResult<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["result"];
 }
 
 class Factory extends ContractFactory<AssertInstance, {}> {
@@ -84,4 +98,12 @@ export class AssertInstance extends ContractInstance {
   async fetchState(): Promise<AssertTypes.State> {
     return fetchContractState(Assert, this);
   }
+
+  methods = {
+    test: async (
+      params: AssertTypes.SignExecuteMethodParams<"test">
+    ): Promise<AssertTypes.SignExecuteMethodResult<"test">> => {
+      return signExecuteMethod(Assert, this, "test", params);
+    },
+  };
 }

--- a/artifacts/ts/Debug.ts
+++ b/artifacts/ts/Debug.ts
@@ -37,6 +37,25 @@ import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
 export namespace DebugTypes {
   export type State = Omit<ContractState<any>, "fields">;
 
+  export interface CallMethodTable {
+    debug: {
+      params: Omit<CallContractParams<{}>, "args">;
+      result: CallContractResult<null>;
+    };
+  }
+  export type CallMethodParams<T extends keyof CallMethodTable> =
+    CallMethodTable[T]["params"];
+  export type CallMethodResult<T extends keyof CallMethodTable> =
+    CallMethodTable[T]["result"];
+  export type MultiCallParams = Partial<{
+    [Name in keyof CallMethodTable]: CallMethodTable[Name]["params"];
+  }>;
+  export type MultiCallResults<T extends MultiCallParams> = {
+    [MaybeName in keyof T]: MaybeName extends keyof CallMethodTable
+      ? CallMethodTable[MaybeName]["result"]
+      : undefined;
+  };
+
   export interface SignExecuteMethodTable {
     debug: {
       params: Omit<SignExecuteContractMethodParams<{}>, "args">;
@@ -87,6 +106,22 @@ export class DebugInstance extends ContractInstance {
   }
 
   methods = {
+    debug: async (
+      params?: DebugTypes.CallMethodParams<"debug">
+    ): Promise<DebugTypes.CallMethodResult<"debug">> => {
+      return callMethod(
+        Debug,
+        this,
+        "debug",
+        params === undefined ? {} : params,
+        getContractByCodeHash
+      );
+    },
+  };
+
+  call = this.methods;
+
+  transaction = {
     debug: async (
       params: DebugTypes.SignExecuteMethodParams<"debug">
     ): Promise<DebugTypes.SignExecuteMethodResult<"debug">> => {

--- a/artifacts/ts/Debug.ts
+++ b/artifacts/ts/Debug.ts
@@ -31,7 +31,14 @@ import {
 } from "@alephium/web3";
 import { default as DebugContractJson } from "../test/Debug.ral.json";
 import { getContractByCodeHash } from "./contracts";
-import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
+import {
+  AddStruct1,
+  AddStruct2,
+  Balances,
+  MapValue,
+  TokenBalance,
+  AllStructs,
+} from "./types";
 
 // Custom types for the contract
 export namespace DebugTypes {

--- a/artifacts/ts/Debug.ts
+++ b/artifacts/ts/Debug.ts
@@ -25,6 +25,9 @@ import {
   getContractEventsCurrentCount,
   TestContractParamsWithoutMaps,
   TestContractResultWithoutMaps,
+  SignExecuteContractMethodParams,
+  SignExecuteScriptTxResult,
+  signExecuteMethod,
 } from "@alephium/web3";
 import { default as DebugContractJson } from "../test/Debug.ral.json";
 import { getContractByCodeHash } from "./contracts";
@@ -33,6 +36,17 @@ import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
 // Custom types for the contract
 export namespace DebugTypes {
   export type State = Omit<ContractState<any>, "fields">;
+
+  export interface SignExecuteMethodTable {
+    debug: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+  }
+  export type SignExecuteMethodParams<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["params"];
+  export type SignExecuteMethodResult<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["result"];
 }
 
 class Factory extends ContractFactory<DebugInstance, {}> {
@@ -71,4 +85,12 @@ export class DebugInstance extends ContractInstance {
   async fetchState(): Promise<DebugTypes.State> {
     return fetchContractState(Debug, this);
   }
+
+  methods = {
+    debug: async (
+      params: DebugTypes.SignExecuteMethodParams<"debug">
+    ): Promise<DebugTypes.SignExecuteMethodResult<"debug">> => {
+      return signExecuteMethod(Debug, this, "debug", params);
+    },
+  };
 }

--- a/artifacts/ts/DeprecatedNFTTest1.ts
+++ b/artifacts/ts/DeprecatedNFTTest1.ts
@@ -60,6 +60,17 @@ export namespace DeprecatedNFTTest1Types {
       ? CallMethodTable[MaybeName]["result"]
       : undefined;
   };
+
+  export interface SignExecuteMethodTable {
+    getTokenUri: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+  }
+  export type SignExecuteMethodParams<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["params"];
+  export type SignExecuteMethodResult<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["result"];
 }
 
 class Factory extends ContractFactory<
@@ -117,6 +128,18 @@ export class DeprecatedNFTTest1Instance extends ContractInstance {
         params === undefined ? {} : params,
         getContractByCodeHash
       );
+    },
+  };
+
+  call = this.methods;
+
+  transaction = {
+    getTokenUri: async (
+      params: DeprecatedNFTTest1Types.SignExecuteMethodParams<"getTokenUri">
+    ): Promise<
+      DeprecatedNFTTest1Types.SignExecuteMethodResult<"getTokenUri">
+    > => {
+      return signExecuteMethod(DeprecatedNFTTest1, this, "getTokenUri", params);
     },
   };
 

--- a/artifacts/ts/DeprecatedNFTTest1.ts
+++ b/artifacts/ts/DeprecatedNFTTest1.ts
@@ -25,6 +25,9 @@ import {
   getContractEventsCurrentCount,
   TestContractParamsWithoutMaps,
   TestContractResultWithoutMaps,
+  SignExecuteContractMethodParams,
+  SignExecuteScriptTxResult,
+  signExecuteMethod,
 } from "@alephium/web3";
 import { default as DeprecatedNFTTest1ContractJson } from "../nft/DeprecatedNFTTest1.ral.json";
 import { getContractByCodeHash } from "./contracts";

--- a/artifacts/ts/DeprecatedNFTTest1.ts
+++ b/artifacts/ts/DeprecatedNFTTest1.ts
@@ -31,7 +31,14 @@ import {
 } from "@alephium/web3";
 import { default as DeprecatedNFTTest1ContractJson } from "../nft/DeprecatedNFTTest1.ral.json";
 import { getContractByCodeHash } from "./contracts";
-import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
+import {
+  AddStruct1,
+  AddStruct2,
+  Balances,
+  MapValue,
+  TokenBalance,
+  AllStructs,
+} from "./types";
 
 // Custom types for the contract
 export namespace DeprecatedNFTTest1Types {

--- a/artifacts/ts/DeprecatedNFTTest2.ts
+++ b/artifacts/ts/DeprecatedNFTTest2.ts
@@ -31,7 +31,14 @@ import {
 } from "@alephium/web3";
 import { default as DeprecatedNFTTest2ContractJson } from "../nft/DeprecatedNFTTest2.ral.json";
 import { getContractByCodeHash } from "./contracts";
-import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
+import {
+  AddStruct1,
+  AddStruct2,
+  Balances,
+  MapValue,
+  TokenBalance,
+  AllStructs,
+} from "./types";
 
 // Custom types for the contract
 export namespace DeprecatedNFTTest2Types {

--- a/artifacts/ts/DeprecatedNFTTest2.ts
+++ b/artifacts/ts/DeprecatedNFTTest2.ts
@@ -25,6 +25,9 @@ import {
   getContractEventsCurrentCount,
   TestContractParamsWithoutMaps,
   TestContractResultWithoutMaps,
+  SignExecuteContractMethodParams,
+  SignExecuteScriptTxResult,
+  signExecuteMethod,
 } from "@alephium/web3";
 import { default as DeprecatedNFTTest2ContractJson } from "../nft/DeprecatedNFTTest2.ral.json";
 import { getContractByCodeHash } from "./contracts";

--- a/artifacts/ts/DeprecatedNFTTest2.ts
+++ b/artifacts/ts/DeprecatedNFTTest2.ts
@@ -64,6 +64,21 @@ export namespace DeprecatedNFTTest2Types {
       ? CallMethodTable[MaybeName]["result"]
       : undefined;
   };
+
+  export interface SignExecuteMethodTable {
+    getTokenUri: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+    getCollectionId: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+  }
+  export type SignExecuteMethodParams<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["params"];
+  export type SignExecuteMethodResult<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["result"];
 }
 
 class Factory extends ContractFactory<
@@ -139,6 +154,30 @@ export class DeprecatedNFTTest2Instance extends ContractInstance {
         "getCollectionId",
         params === undefined ? {} : params,
         getContractByCodeHash
+      );
+    },
+  };
+
+  call = this.methods;
+
+  transaction = {
+    getTokenUri: async (
+      params: DeprecatedNFTTest2Types.SignExecuteMethodParams<"getTokenUri">
+    ): Promise<
+      DeprecatedNFTTest2Types.SignExecuteMethodResult<"getTokenUri">
+    > => {
+      return signExecuteMethod(DeprecatedNFTTest2, this, "getTokenUri", params);
+    },
+    getCollectionId: async (
+      params: DeprecatedNFTTest2Types.SignExecuteMethodParams<"getCollectionId">
+    ): Promise<
+      DeprecatedNFTTest2Types.SignExecuteMethodResult<"getCollectionId">
+    > => {
+      return signExecuteMethod(
+        DeprecatedNFTTest2,
+        this,
+        "getCollectionId",
+        params
       );
     },
   };

--- a/artifacts/ts/DeprecatedNFTTest3.ts
+++ b/artifacts/ts/DeprecatedNFTTest3.ts
@@ -31,7 +31,14 @@ import {
 } from "@alephium/web3";
 import { default as DeprecatedNFTTest3ContractJson } from "../nft/DeprecatedNFTTest3.ral.json";
 import { getContractByCodeHash } from "./contracts";
-import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
+import {
+  AddStruct1,
+  AddStruct2,
+  Balances,
+  MapValue,
+  TokenBalance,
+  AllStructs,
+} from "./types";
 
 // Custom types for the contract
 export namespace DeprecatedNFTTest3Types {

--- a/artifacts/ts/DeprecatedNFTTest3.ts
+++ b/artifacts/ts/DeprecatedNFTTest3.ts
@@ -47,6 +47,10 @@ export namespace DeprecatedNFTTest3Types {
       params: Omit<CallContractParams<{}>, "args">;
       result: CallContractResult<HexString>;
     };
+    returnNothing: {
+      params: Omit<CallContractParams<{}>, "args">;
+      result: CallContractResult<null>;
+    };
   }
   export type CallMethodParams<T extends keyof CallMethodTable> =
     CallMethodTable[T]["params"];
@@ -62,6 +66,10 @@ export namespace DeprecatedNFTTest3Types {
   };
 
   export interface SignExecuteMethodTable {
+    getTokenUri: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
     returnNothing: {
       params: Omit<SignExecuteContractMethodParams<{}>, "args">;
       result: SignExecuteScriptTxResult;
@@ -136,6 +144,29 @@ export class DeprecatedNFTTest3Instance extends ContractInstance {
         params === undefined ? {} : params,
         getContractByCodeHash
       );
+    },
+    returnNothing: async (
+      params?: DeprecatedNFTTest3Types.CallMethodParams<"returnNothing">
+    ): Promise<DeprecatedNFTTest3Types.CallMethodResult<"returnNothing">> => {
+      return callMethod(
+        DeprecatedNFTTest3,
+        this,
+        "returnNothing",
+        params === undefined ? {} : params,
+        getContractByCodeHash
+      );
+    },
+  };
+
+  call = this.methods;
+
+  transaction = {
+    getTokenUri: async (
+      params: DeprecatedNFTTest3Types.SignExecuteMethodParams<"getTokenUri">
+    ): Promise<
+      DeprecatedNFTTest3Types.SignExecuteMethodResult<"getTokenUri">
+    > => {
+      return signExecuteMethod(DeprecatedNFTTest3, this, "getTokenUri", params);
     },
     returnNothing: async (
       params: DeprecatedNFTTest3Types.SignExecuteMethodParams<"returnNothing">

--- a/artifacts/ts/DeprecatedNFTTest3.ts
+++ b/artifacts/ts/DeprecatedNFTTest3.ts
@@ -25,6 +25,9 @@ import {
   getContractEventsCurrentCount,
   TestContractParamsWithoutMaps,
   TestContractResultWithoutMaps,
+  SignExecuteContractMethodParams,
+  SignExecuteScriptTxResult,
+  signExecuteMethod,
 } from "@alephium/web3";
 import { default as DeprecatedNFTTest3ContractJson } from "../nft/DeprecatedNFTTest3.ral.json";
 import { getContractByCodeHash } from "./contracts";
@@ -57,6 +60,17 @@ export namespace DeprecatedNFTTest3Types {
       ? CallMethodTable[MaybeName]["result"]
       : undefined;
   };
+
+  export interface SignExecuteMethodTable {
+    returnNothing: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+  }
+  export type SignExecuteMethodParams<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["params"];
+  export type SignExecuteMethodResult<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["result"];
 }
 
 class Factory extends ContractFactory<
@@ -121,6 +135,18 @@ export class DeprecatedNFTTest3Instance extends ContractInstance {
         "getTokenUri",
         params === undefined ? {} : params,
         getContractByCodeHash
+      );
+    },
+    returnNothing: async (
+      params: DeprecatedNFTTest3Types.SignExecuteMethodParams<"returnNothing">
+    ): Promise<
+      DeprecatedNFTTest3Types.SignExecuteMethodResult<"returnNothing">
+    > => {
+      return signExecuteMethod(
+        DeprecatedNFTTest3,
+        this,
+        "returnNothing",
+        params
       );
     },
   };

--- a/artifacts/ts/DeprecatedNFTTest4.ts
+++ b/artifacts/ts/DeprecatedNFTTest4.ts
@@ -25,6 +25,9 @@ import {
   getContractEventsCurrentCount,
   TestContractParamsWithoutMaps,
   TestContractResultWithoutMaps,
+  SignExecuteContractMethodParams,
+  SignExecuteScriptTxResult,
+  signExecuteMethod,
 } from "@alephium/web3";
 import { default as DeprecatedNFTTest4ContractJson } from "../nft/DeprecatedNFTTest4.ral.json";
 import { getContractByCodeHash } from "./contracts";

--- a/artifacts/ts/DeprecatedNFTTest4.ts
+++ b/artifacts/ts/DeprecatedNFTTest4.ts
@@ -31,7 +31,14 @@ import {
 } from "@alephium/web3";
 import { default as DeprecatedNFTTest4ContractJson } from "../nft/DeprecatedNFTTest4.ral.json";
 import { getContractByCodeHash } from "./contracts";
-import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
+import {
+  AddStruct1,
+  AddStruct2,
+  Balances,
+  MapValue,
+  TokenBalance,
+  AllStructs,
+} from "./types";
 
 // Custom types for the contract
 export namespace DeprecatedNFTTest4Types {

--- a/artifacts/ts/DeprecatedNFTTest4.ts
+++ b/artifacts/ts/DeprecatedNFTTest4.ts
@@ -64,6 +64,21 @@ export namespace DeprecatedNFTTest4Types {
       ? CallMethodTable[MaybeName]["result"]
       : undefined;
   };
+
+  export interface SignExecuteMethodTable {
+    getTokenUri: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+    getBool: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+  }
+  export type SignExecuteMethodParams<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["params"];
+  export type SignExecuteMethodResult<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["result"];
 }
 
 class Factory extends ContractFactory<
@@ -140,6 +155,23 @@ export class DeprecatedNFTTest4Instance extends ContractInstance {
         params === undefined ? {} : params,
         getContractByCodeHash
       );
+    },
+  };
+
+  call = this.methods;
+
+  transaction = {
+    getTokenUri: async (
+      params: DeprecatedNFTTest4Types.SignExecuteMethodParams<"getTokenUri">
+    ): Promise<
+      DeprecatedNFTTest4Types.SignExecuteMethodResult<"getTokenUri">
+    > => {
+      return signExecuteMethod(DeprecatedNFTTest4, this, "getTokenUri", params);
+    },
+    getBool: async (
+      params: DeprecatedNFTTest4Types.SignExecuteMethodParams<"getBool">
+    ): Promise<DeprecatedNFTTest4Types.SignExecuteMethodResult<"getBool">> => {
+      return signExecuteMethod(DeprecatedNFTTest4, this, "getBool", params);
     },
   };
 

--- a/artifacts/ts/DeprecatedNFTTest5.ts
+++ b/artifacts/ts/DeprecatedNFTTest5.ts
@@ -31,7 +31,14 @@ import {
 } from "@alephium/web3";
 import { default as DeprecatedNFTTest5ContractJson } from "../nft/DeprecatedNFTTest5.ral.json";
 import { getContractByCodeHash } from "./contracts";
-import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
+import {
+  AddStruct1,
+  AddStruct2,
+  Balances,
+  MapValue,
+  TokenBalance,
+  AllStructs,
+} from "./types";
 
 // Custom types for the contract
 export namespace DeprecatedNFTTest5Types {

--- a/artifacts/ts/DeprecatedNFTTest5.ts
+++ b/artifacts/ts/DeprecatedNFTTest5.ts
@@ -25,6 +25,9 @@ import {
   getContractEventsCurrentCount,
   TestContractParamsWithoutMaps,
   TestContractResultWithoutMaps,
+  SignExecuteContractMethodParams,
+  SignExecuteScriptTxResult,
+  signExecuteMethod,
 } from "@alephium/web3";
 import { default as DeprecatedNFTTest5ContractJson } from "../nft/DeprecatedNFTTest5.ral.json";
 import { getContractByCodeHash } from "./contracts";

--- a/artifacts/ts/DeprecatedNFTTest5.ts
+++ b/artifacts/ts/DeprecatedNFTTest5.ts
@@ -64,6 +64,21 @@ export namespace DeprecatedNFTTest5Types {
       ? CallMethodTable[MaybeName]["result"]
       : undefined;
   };
+
+  export interface SignExecuteMethodTable {
+    getTokenUri: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+    returnMoreValues: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+  }
+  export type SignExecuteMethodParams<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["params"];
+  export type SignExecuteMethodResult<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["result"];
 }
 
 class Factory extends ContractFactory<
@@ -141,6 +156,30 @@ export class DeprecatedNFTTest5Instance extends ContractInstance {
         "returnMoreValues",
         params === undefined ? {} : params,
         getContractByCodeHash
+      );
+    },
+  };
+
+  call = this.methods;
+
+  transaction = {
+    getTokenUri: async (
+      params: DeprecatedNFTTest5Types.SignExecuteMethodParams<"getTokenUri">
+    ): Promise<
+      DeprecatedNFTTest5Types.SignExecuteMethodResult<"getTokenUri">
+    > => {
+      return signExecuteMethod(DeprecatedNFTTest5, this, "getTokenUri", params);
+    },
+    returnMoreValues: async (
+      params: DeprecatedNFTTest5Types.SignExecuteMethodParams<"returnMoreValues">
+    ): Promise<
+      DeprecatedNFTTest5Types.SignExecuteMethodResult<"returnMoreValues">
+    > => {
+      return signExecuteMethod(
+        DeprecatedNFTTest5,
+        this,
+        "returnMoreValues",
+        params
       );
     },
   };

--- a/artifacts/ts/DeprecatedNFTTest6.ts
+++ b/artifacts/ts/DeprecatedNFTTest6.ts
@@ -31,7 +31,14 @@ import {
 } from "@alephium/web3";
 import { default as DeprecatedNFTTest6ContractJson } from "../nft/DeprecatedNFTTest6.ral.json";
 import { getContractByCodeHash } from "./contracts";
-import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
+import {
+  AddStruct1,
+  AddStruct2,
+  Balances,
+  MapValue,
+  TokenBalance,
+  AllStructs,
+} from "./types";
 
 // Custom types for the contract
 export namespace DeprecatedNFTTest6Types {

--- a/artifacts/ts/DeprecatedNFTTest6.ts
+++ b/artifacts/ts/DeprecatedNFTTest6.ts
@@ -25,6 +25,9 @@ import {
   getContractEventsCurrentCount,
   TestContractParamsWithoutMaps,
   TestContractResultWithoutMaps,
+  SignExecuteContractMethodParams,
+  SignExecuteScriptTxResult,
+  signExecuteMethod,
 } from "@alephium/web3";
 import { default as DeprecatedNFTTest6ContractJson } from "../nft/DeprecatedNFTTest6.ral.json";
 import { getContractByCodeHash } from "./contracts";

--- a/artifacts/ts/DeprecatedNFTTest6.ts
+++ b/artifacts/ts/DeprecatedNFTTest6.ts
@@ -64,6 +64,21 @@ export namespace DeprecatedNFTTest6Types {
       ? CallMethodTable[MaybeName]["result"]
       : undefined;
   };
+
+  export interface SignExecuteMethodTable {
+    getTokenUri: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+    getArray: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+  }
+  export type SignExecuteMethodParams<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["params"];
+  export type SignExecuteMethodResult<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["result"];
 }
 
 class Factory extends ContractFactory<
@@ -140,6 +155,23 @@ export class DeprecatedNFTTest6Instance extends ContractInstance {
         params === undefined ? {} : params,
         getContractByCodeHash
       );
+    },
+  };
+
+  call = this.methods;
+
+  transaction = {
+    getTokenUri: async (
+      params: DeprecatedNFTTest6Types.SignExecuteMethodParams<"getTokenUri">
+    ): Promise<
+      DeprecatedNFTTest6Types.SignExecuteMethodResult<"getTokenUri">
+    > => {
+      return signExecuteMethod(DeprecatedNFTTest6, this, "getTokenUri", params);
+    },
+    getArray: async (
+      params: DeprecatedNFTTest6Types.SignExecuteMethodParams<"getArray">
+    ): Promise<DeprecatedNFTTest6Types.SignExecuteMethodResult<"getArray">> => {
+      return signExecuteMethod(DeprecatedNFTTest6, this, "getArray", params);
     },
   };
 

--- a/artifacts/ts/DeprecatedNFTTest7.ts
+++ b/artifacts/ts/DeprecatedNFTTest7.ts
@@ -25,6 +25,9 @@ import {
   getContractEventsCurrentCount,
   TestContractParamsWithoutMaps,
   TestContractResultWithoutMaps,
+  SignExecuteContractMethodParams,
+  SignExecuteScriptTxResult,
+  signExecuteMethod,
 } from "@alephium/web3";
 import { default as DeprecatedNFTTest7ContractJson } from "../nft/DeprecatedNFTTest7.ral.json";
 import { getContractByCodeHash } from "./contracts";

--- a/artifacts/ts/DeprecatedNFTTest7.ts
+++ b/artifacts/ts/DeprecatedNFTTest7.ts
@@ -31,7 +31,14 @@ import {
 } from "@alephium/web3";
 import { default as DeprecatedNFTTest7ContractJson } from "../nft/DeprecatedNFTTest7.ral.json";
 import { getContractByCodeHash } from "./contracts";
-import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
+import {
+  AddStruct1,
+  AddStruct2,
+  Balances,
+  MapValue,
+  TokenBalance,
+  AllStructs,
+} from "./types";
 
 // Custom types for the contract
 export namespace DeprecatedNFTTest7Types {

--- a/artifacts/ts/DeprecatedNFTTest7.ts
+++ b/artifacts/ts/DeprecatedNFTTest7.ts
@@ -64,6 +64,21 @@ export namespace DeprecatedNFTTest7Types {
       ? CallMethodTable[MaybeName]["result"]
       : undefined;
   };
+
+  export interface SignExecuteMethodTable {
+    getTokenUri: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+    returnNegativeIndex: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+  }
+  export type SignExecuteMethodParams<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["params"];
+  export type SignExecuteMethodResult<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["result"];
 }
 
 class Factory extends ContractFactory<
@@ -141,6 +156,30 @@ export class DeprecatedNFTTest7Instance extends ContractInstance {
         "returnNegativeIndex",
         params === undefined ? {} : params,
         getContractByCodeHash
+      );
+    },
+  };
+
+  call = this.methods;
+
+  transaction = {
+    getTokenUri: async (
+      params: DeprecatedNFTTest7Types.SignExecuteMethodParams<"getTokenUri">
+    ): Promise<
+      DeprecatedNFTTest7Types.SignExecuteMethodResult<"getTokenUri">
+    > => {
+      return signExecuteMethod(DeprecatedNFTTest7, this, "getTokenUri", params);
+    },
+    returnNegativeIndex: async (
+      params: DeprecatedNFTTest7Types.SignExecuteMethodParams<"returnNegativeIndex">
+    ): Promise<
+      DeprecatedNFTTest7Types.SignExecuteMethodResult<"returnNegativeIndex">
+    > => {
+      return signExecuteMethod(
+        DeprecatedNFTTest7,
+        this,
+        "returnNegativeIndex",
+        params
       );
     },
   };

--- a/artifacts/ts/FakeTokenTest.ts
+++ b/artifacts/ts/FakeTokenTest.ts
@@ -58,6 +58,10 @@ export namespace FakeTokenTestTypes {
       params: Omit<CallContractParams<{}>, "args">;
       result: CallContractResult<bigint>;
     };
+    foo: {
+      params: Omit<CallContractParams<{}>, "args">;
+      result: CallContractResult<null>;
+    };
   }
   export type CallMethodParams<T extends keyof CallMethodTable> =
     CallMethodTable[T]["params"];
@@ -73,6 +77,22 @@ export namespace FakeTokenTestTypes {
   };
 
   export interface SignExecuteMethodTable {
+    getSymbol: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+    getName: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+    getDecimals: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+    getTotalSupply: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
     foo: {
       params: Omit<SignExecuteContractMethodParams<{}>, "args">;
       result: SignExecuteScriptTxResult;
@@ -204,6 +224,44 @@ export class FakeTokenTestInstance extends ContractInstance {
         params === undefined ? {} : params,
         getContractByCodeHash
       );
+    },
+    foo: async (
+      params?: FakeTokenTestTypes.CallMethodParams<"foo">
+    ): Promise<FakeTokenTestTypes.CallMethodResult<"foo">> => {
+      return callMethod(
+        FakeTokenTest,
+        this,
+        "foo",
+        params === undefined ? {} : params,
+        getContractByCodeHash
+      );
+    },
+  };
+
+  call = this.methods;
+
+  transaction = {
+    getSymbol: async (
+      params: FakeTokenTestTypes.SignExecuteMethodParams<"getSymbol">
+    ): Promise<FakeTokenTestTypes.SignExecuteMethodResult<"getSymbol">> => {
+      return signExecuteMethod(FakeTokenTest, this, "getSymbol", params);
+    },
+    getName: async (
+      params: FakeTokenTestTypes.SignExecuteMethodParams<"getName">
+    ): Promise<FakeTokenTestTypes.SignExecuteMethodResult<"getName">> => {
+      return signExecuteMethod(FakeTokenTest, this, "getName", params);
+    },
+    getDecimals: async (
+      params: FakeTokenTestTypes.SignExecuteMethodParams<"getDecimals">
+    ): Promise<FakeTokenTestTypes.SignExecuteMethodResult<"getDecimals">> => {
+      return signExecuteMethod(FakeTokenTest, this, "getDecimals", params);
+    },
+    getTotalSupply: async (
+      params: FakeTokenTestTypes.SignExecuteMethodParams<"getTotalSupply">
+    ): Promise<
+      FakeTokenTestTypes.SignExecuteMethodResult<"getTotalSupply">
+    > => {
+      return signExecuteMethod(FakeTokenTest, this, "getTotalSupply", params);
     },
     foo: async (
       params: FakeTokenTestTypes.SignExecuteMethodParams<"foo">

--- a/artifacts/ts/FakeTokenTest.ts
+++ b/artifacts/ts/FakeTokenTest.ts
@@ -31,7 +31,14 @@ import {
 } from "@alephium/web3";
 import { default as FakeTokenTestContractJson } from "../token/FakeTokenTest.ral.json";
 import { getContractByCodeHash } from "./contracts";
-import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
+import {
+  AddStruct1,
+  AddStruct2,
+  Balances,
+  MapValue,
+  TokenBalance,
+  AllStructs,
+} from "./types";
 
 // Custom types for the contract
 export namespace FakeTokenTestTypes {

--- a/artifacts/ts/FakeTokenTest.ts
+++ b/artifacts/ts/FakeTokenTest.ts
@@ -25,6 +25,9 @@ import {
   getContractEventsCurrentCount,
   TestContractParamsWithoutMaps,
   TestContractResultWithoutMaps,
+  SignExecuteContractMethodParams,
+  SignExecuteScriptTxResult,
+  signExecuteMethod,
 } from "@alephium/web3";
 import { default as FakeTokenTestContractJson } from "../token/FakeTokenTest.ral.json";
 import { getContractByCodeHash } from "./contracts";
@@ -68,6 +71,17 @@ export namespace FakeTokenTestTypes {
       ? CallMethodTable[MaybeName]["result"]
       : undefined;
   };
+
+  export interface SignExecuteMethodTable {
+    foo: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+  }
+  export type SignExecuteMethodParams<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["params"];
+  export type SignExecuteMethodResult<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["result"];
 }
 
 class Factory extends ContractFactory<
@@ -190,6 +204,11 @@ export class FakeTokenTestInstance extends ContractInstance {
         params === undefined ? {} : params,
         getContractByCodeHash
       );
+    },
+    foo: async (
+      params: FakeTokenTestTypes.SignExecuteMethodParams<"foo">
+    ): Promise<FakeTokenTestTypes.SignExecuteMethodResult<"foo">> => {
+      return signExecuteMethod(FakeTokenTest, this, "foo", params);
     },
   };
 

--- a/artifacts/ts/Greeter.ts
+++ b/artifacts/ts/Greeter.ts
@@ -31,7 +31,14 @@ import {
 } from "@alephium/web3";
 import { default as GreeterContractJson } from "../greeter/Greeter.ral.json";
 import { getContractByCodeHash } from "./contracts";
-import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
+import {
+  AddStruct1,
+  AddStruct2,
+  Balances,
+  MapValue,
+  TokenBalance,
+  AllStructs,
+} from "./types";
 
 // Custom types for the contract
 export namespace GreeterTypes {

--- a/artifacts/ts/Greeter.ts
+++ b/artifacts/ts/Greeter.ts
@@ -25,6 +25,9 @@ import {
   getContractEventsCurrentCount,
   TestContractParamsWithoutMaps,
   TestContractResultWithoutMaps,
+  SignExecuteContractMethodParams,
+  SignExecuteScriptTxResult,
+  signExecuteMethod,
 } from "@alephium/web3";
 import { default as GreeterContractJson } from "../greeter/Greeter.ral.json";
 import { getContractByCodeHash } from "./contracts";

--- a/artifacts/ts/Greeter.ts
+++ b/artifacts/ts/Greeter.ts
@@ -67,6 +67,17 @@ export namespace GreeterTypes {
       ? CallMethodTable[MaybeName]["result"]
       : undefined;
   };
+
+  export interface SignExecuteMethodTable {
+    greet: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+  }
+  export type SignExecuteMethodParams<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["params"];
+  export type SignExecuteMethodResult<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["result"];
 }
 
 class Factory extends ContractFactory<GreeterInstance, GreeterTypes.Fields> {
@@ -121,6 +132,16 @@ export class GreeterInstance extends ContractInstance {
         params === undefined ? {} : params,
         getContractByCodeHash
       );
+    },
+  };
+
+  call = this.methods;
+
+  transaction = {
+    greet: async (
+      params: GreeterTypes.SignExecuteMethodParams<"greet">
+    ): Promise<GreeterTypes.SignExecuteMethodResult<"greet">> => {
+      return signExecuteMethod(Greeter, this, "greet", params);
     },
   };
 

--- a/artifacts/ts/MapTest.ts
+++ b/artifacts/ts/MapTest.ts
@@ -25,6 +25,9 @@ import {
   getContractEventsCurrentCount,
   TestContractParamsWithoutMaps,
   TestContractResultWithoutMaps,
+  SignExecuteContractMethodParams,
+  SignExecuteScriptTxResult,
+  signExecuteMethod,
 } from "@alephium/web3";
 import { default as MapTestContractJson } from "../test/MapTest.ral.json";
 import { getContractByCodeHash } from "./contracts";
@@ -56,6 +59,28 @@ export namespace MapTestTypes {
       ? CallMethodTable[MaybeName]["result"]
       : undefined;
   };
+
+  export interface SignExecuteMethodTable {
+    insert: {
+      params: SignExecuteContractMethodParams<{
+        key: Address;
+        value: MapValue;
+      }>;
+      result: SignExecuteScriptTxResult;
+    };
+    update: {
+      params: SignExecuteContractMethodParams<{ key: Address }>;
+      result: SignExecuteScriptTxResult;
+    };
+    remove: {
+      params: SignExecuteContractMethodParams<{ key: Address }>;
+      result: SignExecuteScriptTxResult;
+    };
+  }
+  export type SignExecuteMethodParams<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["params"];
+  export type SignExecuteMethodResult<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["result"];
 }
 
 class Factory extends ContractFactory<MapTestInstance, {}> {
@@ -173,6 +198,21 @@ export class MapTestInstance extends ContractInstance {
   }
 
   methods = {
+    insert: async (
+      params: MapTestTypes.SignExecuteMethodParams<"insert">
+    ): Promise<MapTestTypes.SignExecuteMethodResult<"insert">> => {
+      return signExecuteMethod(MapTest, this, "insert", params);
+    },
+    update: async (
+      params: MapTestTypes.SignExecuteMethodParams<"update">
+    ): Promise<MapTestTypes.SignExecuteMethodResult<"update">> => {
+      return signExecuteMethod(MapTest, this, "update", params);
+    },
+    remove: async (
+      params: MapTestTypes.SignExecuteMethodParams<"remove">
+    ): Promise<MapTestTypes.SignExecuteMethodResult<"remove">> => {
+      return signExecuteMethod(MapTest, this, "remove", params);
+    },
     get: async (
       params: MapTestTypes.CallMethodParams<"get">
     ): Promise<MapTestTypes.CallMethodResult<"get">> => {

--- a/artifacts/ts/MapTest.ts
+++ b/artifacts/ts/MapTest.ts
@@ -38,6 +38,18 @@ export namespace MapTestTypes {
   export type State = Omit<ContractState<any>, "fields">;
 
   export interface CallMethodTable {
+    insert: {
+      params: CallContractParams<{ key: Address; value: MapValue }>;
+      result: CallContractResult<null>;
+    };
+    update: {
+      params: CallContractParams<{ key: Address }>;
+      result: CallContractResult<null>;
+    };
+    remove: {
+      params: CallContractParams<{ key: Address }>;
+      result: CallContractResult<null>;
+    };
     get: {
       params: CallContractParams<{ key: Address }>;
       result: CallContractResult<MapValue>;
@@ -73,6 +85,14 @@ export namespace MapTestTypes {
       result: SignExecuteScriptTxResult;
     };
     remove: {
+      params: SignExecuteContractMethodParams<{ key: Address }>;
+      result: SignExecuteScriptTxResult;
+    };
+    get: {
+      params: SignExecuteContractMethodParams<{ key: Address }>;
+      result: SignExecuteScriptTxResult;
+    };
+    contains: {
       params: SignExecuteContractMethodParams<{ key: Address }>;
       result: SignExecuteScriptTxResult;
     };
@@ -199,19 +219,19 @@ export class MapTestInstance extends ContractInstance {
 
   methods = {
     insert: async (
-      params: MapTestTypes.SignExecuteMethodParams<"insert">
-    ): Promise<MapTestTypes.SignExecuteMethodResult<"insert">> => {
-      return signExecuteMethod(MapTest, this, "insert", params);
+      params: MapTestTypes.CallMethodParams<"insert">
+    ): Promise<MapTestTypes.CallMethodResult<"insert">> => {
+      return callMethod(MapTest, this, "insert", params, getContractByCodeHash);
     },
     update: async (
-      params: MapTestTypes.SignExecuteMethodParams<"update">
-    ): Promise<MapTestTypes.SignExecuteMethodResult<"update">> => {
-      return signExecuteMethod(MapTest, this, "update", params);
+      params: MapTestTypes.CallMethodParams<"update">
+    ): Promise<MapTestTypes.CallMethodResult<"update">> => {
+      return callMethod(MapTest, this, "update", params, getContractByCodeHash);
     },
     remove: async (
-      params: MapTestTypes.SignExecuteMethodParams<"remove">
-    ): Promise<MapTestTypes.SignExecuteMethodResult<"remove">> => {
-      return signExecuteMethod(MapTest, this, "remove", params);
+      params: MapTestTypes.CallMethodParams<"remove">
+    ): Promise<MapTestTypes.CallMethodResult<"remove">> => {
+      return callMethod(MapTest, this, "remove", params, getContractByCodeHash);
     },
     get: async (
       params: MapTestTypes.CallMethodParams<"get">
@@ -228,6 +248,36 @@ export class MapTestInstance extends ContractInstance {
         params,
         getContractByCodeHash
       );
+    },
+  };
+
+  call = this.methods;
+
+  transaction = {
+    insert: async (
+      params: MapTestTypes.SignExecuteMethodParams<"insert">
+    ): Promise<MapTestTypes.SignExecuteMethodResult<"insert">> => {
+      return signExecuteMethod(MapTest, this, "insert", params);
+    },
+    update: async (
+      params: MapTestTypes.SignExecuteMethodParams<"update">
+    ): Promise<MapTestTypes.SignExecuteMethodResult<"update">> => {
+      return signExecuteMethod(MapTest, this, "update", params);
+    },
+    remove: async (
+      params: MapTestTypes.SignExecuteMethodParams<"remove">
+    ): Promise<MapTestTypes.SignExecuteMethodResult<"remove">> => {
+      return signExecuteMethod(MapTest, this, "remove", params);
+    },
+    get: async (
+      params: MapTestTypes.SignExecuteMethodParams<"get">
+    ): Promise<MapTestTypes.SignExecuteMethodResult<"get">> => {
+      return signExecuteMethod(MapTest, this, "get", params);
+    },
+    contains: async (
+      params: MapTestTypes.SignExecuteMethodParams<"contains">
+    ): Promise<MapTestTypes.SignExecuteMethodResult<"contains">> => {
+      return signExecuteMethod(MapTest, this, "contains", params);
     },
   };
 

--- a/artifacts/ts/MapTest.ts
+++ b/artifacts/ts/MapTest.ts
@@ -31,7 +31,14 @@ import {
 } from "@alephium/web3";
 import { default as MapTestContractJson } from "../test/MapTest.ral.json";
 import { getContractByCodeHash } from "./contracts";
-import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
+import {
+  AddStruct1,
+  AddStruct2,
+  Balances,
+  MapValue,
+  TokenBalance,
+  AllStructs,
+} from "./types";
 
 // Custom types for the contract
 export namespace MapTestTypes {

--- a/artifacts/ts/MetaData.ts
+++ b/artifacts/ts/MetaData.ts
@@ -25,6 +25,9 @@ import {
   getContractEventsCurrentCount,
   TestContractParamsWithoutMaps,
   TestContractResultWithoutMaps,
+  SignExecuteContractMethodParams,
+  SignExecuteScriptTxResult,
+  signExecuteMethod,
 } from "@alephium/web3";
 import { default as MetaDataContractJson } from "../test/MetaData.ral.json";
 import { getContractByCodeHash } from "./contracts";
@@ -33,6 +36,17 @@ import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
 // Custom types for the contract
 export namespace MetaDataTypes {
   export type State = Omit<ContractState<any>, "fields">;
+
+  export interface SignExecuteMethodTable {
+    foo: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+  }
+  export type SignExecuteMethodParams<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["params"];
+  export type SignExecuteMethodResult<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["result"];
 }
 
 class Factory extends ContractFactory<MetaDataInstance, {}> {
@@ -87,4 +101,12 @@ export class MetaDataInstance extends ContractInstance {
   async fetchState(): Promise<MetaDataTypes.State> {
     return fetchContractState(MetaData, this);
   }
+
+  methods = {
+    foo: async (
+      params: MetaDataTypes.SignExecuteMethodParams<"foo">
+    ): Promise<MetaDataTypes.SignExecuteMethodResult<"foo">> => {
+      return signExecuteMethod(MetaData, this, "foo", params);
+    },
+  };
 }

--- a/artifacts/ts/MetaData.ts
+++ b/artifacts/ts/MetaData.ts
@@ -31,7 +31,14 @@ import {
 } from "@alephium/web3";
 import { default as MetaDataContractJson } from "../test/MetaData.ral.json";
 import { getContractByCodeHash } from "./contracts";
-import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
+import {
+  AddStruct1,
+  AddStruct2,
+  Balances,
+  MapValue,
+  TokenBalance,
+  AllStructs,
+} from "./types";
 
 // Custom types for the contract
 export namespace MetaDataTypes {

--- a/artifacts/ts/MetaData.ts
+++ b/artifacts/ts/MetaData.ts
@@ -37,6 +37,25 @@ import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
 export namespace MetaDataTypes {
   export type State = Omit<ContractState<any>, "fields">;
 
+  export interface CallMethodTable {
+    foo: {
+      params: Omit<CallContractParams<{}>, "args">;
+      result: CallContractResult<null>;
+    };
+  }
+  export type CallMethodParams<T extends keyof CallMethodTable> =
+    CallMethodTable[T]["params"];
+  export type CallMethodResult<T extends keyof CallMethodTable> =
+    CallMethodTable[T]["result"];
+  export type MultiCallParams = Partial<{
+    [Name in keyof CallMethodTable]: CallMethodTable[Name]["params"];
+  }>;
+  export type MultiCallResults<T extends MultiCallParams> = {
+    [MaybeName in keyof T]: MaybeName extends keyof CallMethodTable
+      ? CallMethodTable[MaybeName]["result"]
+      : undefined;
+  };
+
   export interface SignExecuteMethodTable {
     foo: {
       params: Omit<SignExecuteContractMethodParams<{}>, "args">;
@@ -103,6 +122,22 @@ export class MetaDataInstance extends ContractInstance {
   }
 
   methods = {
+    foo: async (
+      params?: MetaDataTypes.CallMethodParams<"foo">
+    ): Promise<MetaDataTypes.CallMethodResult<"foo">> => {
+      return callMethod(
+        MetaData,
+        this,
+        "foo",
+        params === undefined ? {} : params,
+        getContractByCodeHash
+      );
+    },
+  };
+
+  call = this.methods;
+
+  transaction = {
     foo: async (
       params: MetaDataTypes.SignExecuteMethodParams<"foo">
     ): Promise<MetaDataTypes.SignExecuteMethodResult<"foo">> => {

--- a/artifacts/ts/NFTCollectionTest.ts
+++ b/artifacts/ts/NFTCollectionTest.ts
@@ -25,6 +25,9 @@ import {
   getContractEventsCurrentCount,
   TestContractParamsWithoutMaps,
   TestContractResultWithoutMaps,
+  SignExecuteContractMethodParams,
+  SignExecuteScriptTxResult,
+  signExecuteMethod,
 } from "@alephium/web3";
 import { default as NFTCollectionTestContractJson } from "../nft/NFTCollectionTest.ral.json";
 import { getContractByCodeHash } from "./contracts";
@@ -70,6 +73,20 @@ export namespace NFTCollectionTestTypes {
       ? CallMethodTable[MaybeName]["result"]
       : undefined;
   };
+
+  export interface SignExecuteMethodTable {
+    validateNFT: {
+      params: SignExecuteContractMethodParams<{
+        nftId: HexString;
+        nftIndex: bigint;
+      }>;
+      result: SignExecuteScriptTxResult;
+    };
+  }
+  export type SignExecuteMethodParams<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["params"];
+  export type SignExecuteMethodResult<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["result"];
 }
 
 class Factory extends ContractFactory<
@@ -189,6 +206,13 @@ export class NFTCollectionTestInstance extends ContractInstance {
         params,
         getContractByCodeHash
       );
+    },
+    validateNFT: async (
+      params: NFTCollectionTestTypes.SignExecuteMethodParams<"validateNFT">
+    ): Promise<
+      NFTCollectionTestTypes.SignExecuteMethodResult<"validateNFT">
+    > => {
+      return signExecuteMethod(NFTCollectionTest, this, "validateNFT", params);
     },
     mint: async (
       params: NFTCollectionTestTypes.CallMethodParams<"mint">

--- a/artifacts/ts/NFTCollectionTest.ts
+++ b/artifacts/ts/NFTCollectionTest.ts
@@ -31,7 +31,14 @@ import {
 } from "@alephium/web3";
 import { default as NFTCollectionTestContractJson } from "../nft/NFTCollectionTest.ral.json";
 import { getContractByCodeHash } from "./contracts";
-import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
+import {
+  AddStruct1,
+  AddStruct2,
+  Balances,
+  MapValue,
+  TokenBalance,
+  AllStructs,
+} from "./types";
 
 // Custom types for the contract
 export namespace NFTCollectionTestTypes {

--- a/artifacts/ts/NFTCollectionTest.ts
+++ b/artifacts/ts/NFTCollectionTest.ts
@@ -56,6 +56,10 @@ export namespace NFTCollectionTestTypes {
       params: CallContractParams<{ index: bigint }>;
       result: CallContractResult<HexString>;
     };
+    validateNFT: {
+      params: CallContractParams<{ nftId: HexString; nftIndex: bigint }>;
+      result: CallContractResult<null>;
+    };
     mint: {
       params: CallContractParams<{ nftUri: HexString }>;
       result: CallContractResult<HexString>;
@@ -75,11 +79,27 @@ export namespace NFTCollectionTestTypes {
   };
 
   export interface SignExecuteMethodTable {
+    getCollectionUri: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+    totalSupply: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+    nftByIndex: {
+      params: SignExecuteContractMethodParams<{ index: bigint }>;
+      result: SignExecuteScriptTxResult;
+    };
     validateNFT: {
       params: SignExecuteContractMethodParams<{
         nftId: HexString;
         nftIndex: bigint;
       }>;
+      result: SignExecuteScriptTxResult;
+    };
+    mint: {
+      params: SignExecuteContractMethodParams<{ nftUri: HexString }>;
       result: SignExecuteScriptTxResult;
     };
   }
@@ -208,11 +228,15 @@ export class NFTCollectionTestInstance extends ContractInstance {
       );
     },
     validateNFT: async (
-      params: NFTCollectionTestTypes.SignExecuteMethodParams<"validateNFT">
-    ): Promise<
-      NFTCollectionTestTypes.SignExecuteMethodResult<"validateNFT">
-    > => {
-      return signExecuteMethod(NFTCollectionTest, this, "validateNFT", params);
+      params: NFTCollectionTestTypes.CallMethodParams<"validateNFT">
+    ): Promise<NFTCollectionTestTypes.CallMethodResult<"validateNFT">> => {
+      return callMethod(
+        NFTCollectionTest,
+        this,
+        "validateNFT",
+        params,
+        getContractByCodeHash
+      );
     },
     mint: async (
       params: NFTCollectionTestTypes.CallMethodParams<"mint">
@@ -224,6 +248,49 @@ export class NFTCollectionTestInstance extends ContractInstance {
         params,
         getContractByCodeHash
       );
+    },
+  };
+
+  call = this.methods;
+
+  transaction = {
+    getCollectionUri: async (
+      params: NFTCollectionTestTypes.SignExecuteMethodParams<"getCollectionUri">
+    ): Promise<
+      NFTCollectionTestTypes.SignExecuteMethodResult<"getCollectionUri">
+    > => {
+      return signExecuteMethod(
+        NFTCollectionTest,
+        this,
+        "getCollectionUri",
+        params
+      );
+    },
+    totalSupply: async (
+      params: NFTCollectionTestTypes.SignExecuteMethodParams<"totalSupply">
+    ): Promise<
+      NFTCollectionTestTypes.SignExecuteMethodResult<"totalSupply">
+    > => {
+      return signExecuteMethod(NFTCollectionTest, this, "totalSupply", params);
+    },
+    nftByIndex: async (
+      params: NFTCollectionTestTypes.SignExecuteMethodParams<"nftByIndex">
+    ): Promise<
+      NFTCollectionTestTypes.SignExecuteMethodResult<"nftByIndex">
+    > => {
+      return signExecuteMethod(NFTCollectionTest, this, "nftByIndex", params);
+    },
+    validateNFT: async (
+      params: NFTCollectionTestTypes.SignExecuteMethodParams<"validateNFT">
+    ): Promise<
+      NFTCollectionTestTypes.SignExecuteMethodResult<"validateNFT">
+    > => {
+      return signExecuteMethod(NFTCollectionTest, this, "validateNFT", params);
+    },
+    mint: async (
+      params: NFTCollectionTestTypes.SignExecuteMethodParams<"mint">
+    ): Promise<NFTCollectionTestTypes.SignExecuteMethodResult<"mint">> => {
+      return signExecuteMethod(NFTCollectionTest, this, "mint", params);
     },
   };
 

--- a/artifacts/ts/NFTCollectionWithRoyaltyTest.ts
+++ b/artifacts/ts/NFTCollectionWithRoyaltyTest.ts
@@ -58,9 +58,21 @@ export namespace NFTCollectionWithRoyaltyTestTypes {
       params: CallContractParams<{ index: bigint }>;
       result: CallContractResult<HexString>;
     };
+    validateNFT: {
+      params: CallContractParams<{ nftId: HexString; nftIndex: bigint }>;
+      result: CallContractResult<null>;
+    };
     royaltyAmount: {
       params: CallContractParams<{ tokenId: HexString; salePrice: bigint }>;
       result: CallContractResult<bigint>;
+    };
+    payRoyalty: {
+      params: CallContractParams<{ payer: Address; amount: bigint }>;
+      result: CallContractResult<null>;
+    };
+    withdrawRoyalty: {
+      params: CallContractParams<{ recipient: Address; amount: bigint }>;
+      result: CallContractResult<null>;
     };
     mint: {
       params: CallContractParams<{ nftUri: HexString }>;
@@ -81,10 +93,29 @@ export namespace NFTCollectionWithRoyaltyTestTypes {
   };
 
   export interface SignExecuteMethodTable {
+    getCollectionUri: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+    totalSupply: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+    nftByIndex: {
+      params: SignExecuteContractMethodParams<{ index: bigint }>;
+      result: SignExecuteScriptTxResult;
+    };
     validateNFT: {
       params: SignExecuteContractMethodParams<{
         nftId: HexString;
         nftIndex: bigint;
+      }>;
+      result: SignExecuteScriptTxResult;
+    };
+    royaltyAmount: {
+      params: SignExecuteContractMethodParams<{
+        tokenId: HexString;
+        salePrice: bigint;
       }>;
       result: SignExecuteScriptTxResult;
     };
@@ -100,6 +131,10 @@ export namespace NFTCollectionWithRoyaltyTestTypes {
         recipient: Address;
         amount: bigint;
       }>;
+      result: SignExecuteScriptTxResult;
+    };
+    mint: {
+      params: SignExecuteContractMethodParams<{ nftUri: HexString }>;
       result: SignExecuteScriptTxResult;
     };
   }
@@ -265,15 +300,16 @@ export class NFTCollectionWithRoyaltyTestInstance extends ContractInstance {
       );
     },
     validateNFT: async (
-      params: NFTCollectionWithRoyaltyTestTypes.SignExecuteMethodParams<"validateNFT">
+      params: NFTCollectionWithRoyaltyTestTypes.CallMethodParams<"validateNFT">
     ): Promise<
-      NFTCollectionWithRoyaltyTestTypes.SignExecuteMethodResult<"validateNFT">
+      NFTCollectionWithRoyaltyTestTypes.CallMethodResult<"validateNFT">
     > => {
-      return signExecuteMethod(
+      return callMethod(
         NFTCollectionWithRoyaltyTest,
         this,
         "validateNFT",
-        params
+        params,
+        getContractByCodeHash
       );
     },
     royaltyAmount: async (
@@ -287,6 +323,108 @@ export class NFTCollectionWithRoyaltyTestInstance extends ContractInstance {
         "royaltyAmount",
         params,
         getContractByCodeHash
+      );
+    },
+    payRoyalty: async (
+      params: NFTCollectionWithRoyaltyTestTypes.CallMethodParams<"payRoyalty">
+    ): Promise<
+      NFTCollectionWithRoyaltyTestTypes.CallMethodResult<"payRoyalty">
+    > => {
+      return callMethod(
+        NFTCollectionWithRoyaltyTest,
+        this,
+        "payRoyalty",
+        params,
+        getContractByCodeHash
+      );
+    },
+    withdrawRoyalty: async (
+      params: NFTCollectionWithRoyaltyTestTypes.CallMethodParams<"withdrawRoyalty">
+    ): Promise<
+      NFTCollectionWithRoyaltyTestTypes.CallMethodResult<"withdrawRoyalty">
+    > => {
+      return callMethod(
+        NFTCollectionWithRoyaltyTest,
+        this,
+        "withdrawRoyalty",
+        params,
+        getContractByCodeHash
+      );
+    },
+    mint: async (
+      params: NFTCollectionWithRoyaltyTestTypes.CallMethodParams<"mint">
+    ): Promise<NFTCollectionWithRoyaltyTestTypes.CallMethodResult<"mint">> => {
+      return callMethod(
+        NFTCollectionWithRoyaltyTest,
+        this,
+        "mint",
+        params,
+        getContractByCodeHash
+      );
+    },
+  };
+
+  call = this.methods;
+
+  transaction = {
+    getCollectionUri: async (
+      params: NFTCollectionWithRoyaltyTestTypes.SignExecuteMethodParams<"getCollectionUri">
+    ): Promise<
+      NFTCollectionWithRoyaltyTestTypes.SignExecuteMethodResult<"getCollectionUri">
+    > => {
+      return signExecuteMethod(
+        NFTCollectionWithRoyaltyTest,
+        this,
+        "getCollectionUri",
+        params
+      );
+    },
+    totalSupply: async (
+      params: NFTCollectionWithRoyaltyTestTypes.SignExecuteMethodParams<"totalSupply">
+    ): Promise<
+      NFTCollectionWithRoyaltyTestTypes.SignExecuteMethodResult<"totalSupply">
+    > => {
+      return signExecuteMethod(
+        NFTCollectionWithRoyaltyTest,
+        this,
+        "totalSupply",
+        params
+      );
+    },
+    nftByIndex: async (
+      params: NFTCollectionWithRoyaltyTestTypes.SignExecuteMethodParams<"nftByIndex">
+    ): Promise<
+      NFTCollectionWithRoyaltyTestTypes.SignExecuteMethodResult<"nftByIndex">
+    > => {
+      return signExecuteMethod(
+        NFTCollectionWithRoyaltyTest,
+        this,
+        "nftByIndex",
+        params
+      );
+    },
+    validateNFT: async (
+      params: NFTCollectionWithRoyaltyTestTypes.SignExecuteMethodParams<"validateNFT">
+    ): Promise<
+      NFTCollectionWithRoyaltyTestTypes.SignExecuteMethodResult<"validateNFT">
+    > => {
+      return signExecuteMethod(
+        NFTCollectionWithRoyaltyTest,
+        this,
+        "validateNFT",
+        params
+      );
+    },
+    royaltyAmount: async (
+      params: NFTCollectionWithRoyaltyTestTypes.SignExecuteMethodParams<"royaltyAmount">
+    ): Promise<
+      NFTCollectionWithRoyaltyTestTypes.SignExecuteMethodResult<"royaltyAmount">
+    > => {
+      return signExecuteMethod(
+        NFTCollectionWithRoyaltyTest,
+        this,
+        "royaltyAmount",
+        params
       );
     },
     payRoyalty: async (
@@ -314,14 +452,15 @@ export class NFTCollectionWithRoyaltyTestInstance extends ContractInstance {
       );
     },
     mint: async (
-      params: NFTCollectionWithRoyaltyTestTypes.CallMethodParams<"mint">
-    ): Promise<NFTCollectionWithRoyaltyTestTypes.CallMethodResult<"mint">> => {
-      return callMethod(
+      params: NFTCollectionWithRoyaltyTestTypes.SignExecuteMethodParams<"mint">
+    ): Promise<
+      NFTCollectionWithRoyaltyTestTypes.SignExecuteMethodResult<"mint">
+    > => {
+      return signExecuteMethod(
         NFTCollectionWithRoyaltyTest,
         this,
         "mint",
-        params,
-        getContractByCodeHash
+        params
       );
     },
   };

--- a/artifacts/ts/NFTCollectionWithRoyaltyTest.ts
+++ b/artifacts/ts/NFTCollectionWithRoyaltyTest.ts
@@ -31,7 +31,14 @@ import {
 } from "@alephium/web3";
 import { default as NFTCollectionWithRoyaltyTestContractJson } from "../nft/NFTCollectionWithRoyaltyTest.ral.json";
 import { getContractByCodeHash } from "./contracts";
-import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
+import {
+  AddStruct1,
+  AddStruct2,
+  Balances,
+  MapValue,
+  TokenBalance,
+  AllStructs,
+} from "./types";
 
 // Custom types for the contract
 export namespace NFTCollectionWithRoyaltyTestTypes {

--- a/artifacts/ts/NFTCollectionWithRoyaltyTest.ts
+++ b/artifacts/ts/NFTCollectionWithRoyaltyTest.ts
@@ -25,6 +25,9 @@ import {
   getContractEventsCurrentCount,
   TestContractParamsWithoutMaps,
   TestContractResultWithoutMaps,
+  SignExecuteContractMethodParams,
+  SignExecuteScriptTxResult,
+  signExecuteMethod,
 } from "@alephium/web3";
 import { default as NFTCollectionWithRoyaltyTestContractJson } from "../nft/NFTCollectionWithRoyaltyTest.ral.json";
 import { getContractByCodeHash } from "./contracts";
@@ -76,6 +79,34 @@ export namespace NFTCollectionWithRoyaltyTestTypes {
       ? CallMethodTable[MaybeName]["result"]
       : undefined;
   };
+
+  export interface SignExecuteMethodTable {
+    validateNFT: {
+      params: SignExecuteContractMethodParams<{
+        nftId: HexString;
+        nftIndex: bigint;
+      }>;
+      result: SignExecuteScriptTxResult;
+    };
+    payRoyalty: {
+      params: SignExecuteContractMethodParams<{
+        payer: Address;
+        amount: bigint;
+      }>;
+      result: SignExecuteScriptTxResult;
+    };
+    withdrawRoyalty: {
+      params: SignExecuteContractMethodParams<{
+        recipient: Address;
+        amount: bigint;
+      }>;
+      result: SignExecuteScriptTxResult;
+    };
+  }
+  export type SignExecuteMethodParams<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["params"];
+  export type SignExecuteMethodResult<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["result"];
 }
 
 class Factory extends ContractFactory<
@@ -233,6 +264,18 @@ export class NFTCollectionWithRoyaltyTestInstance extends ContractInstance {
         getContractByCodeHash
       );
     },
+    validateNFT: async (
+      params: NFTCollectionWithRoyaltyTestTypes.SignExecuteMethodParams<"validateNFT">
+    ): Promise<
+      NFTCollectionWithRoyaltyTestTypes.SignExecuteMethodResult<"validateNFT">
+    > => {
+      return signExecuteMethod(
+        NFTCollectionWithRoyaltyTest,
+        this,
+        "validateNFT",
+        params
+      );
+    },
     royaltyAmount: async (
       params: NFTCollectionWithRoyaltyTestTypes.CallMethodParams<"royaltyAmount">
     ): Promise<
@@ -244,6 +287,30 @@ export class NFTCollectionWithRoyaltyTestInstance extends ContractInstance {
         "royaltyAmount",
         params,
         getContractByCodeHash
+      );
+    },
+    payRoyalty: async (
+      params: NFTCollectionWithRoyaltyTestTypes.SignExecuteMethodParams<"payRoyalty">
+    ): Promise<
+      NFTCollectionWithRoyaltyTestTypes.SignExecuteMethodResult<"payRoyalty">
+    > => {
+      return signExecuteMethod(
+        NFTCollectionWithRoyaltyTest,
+        this,
+        "payRoyalty",
+        params
+      );
+    },
+    withdrawRoyalty: async (
+      params: NFTCollectionWithRoyaltyTestTypes.SignExecuteMethodParams<"withdrawRoyalty">
+    ): Promise<
+      NFTCollectionWithRoyaltyTestTypes.SignExecuteMethodResult<"withdrawRoyalty">
+    > => {
+      return signExecuteMethod(
+        NFTCollectionWithRoyaltyTest,
+        this,
+        "withdrawRoyalty",
+        params
       );
     },
     mint: async (

--- a/artifacts/ts/NFTTest.ts
+++ b/artifacts/ts/NFTTest.ts
@@ -25,6 +25,9 @@ import {
   getContractEventsCurrentCount,
   TestContractParamsWithoutMaps,
   TestContractResultWithoutMaps,
+  SignExecuteContractMethodParams,
+  SignExecuteScriptTxResult,
+  signExecuteMethod,
 } from "@alephium/web3";
 import { default as NFTTestContractJson } from "../nft/NFTTest.ral.json";
 import { getContractByCodeHash } from "./contracts";

--- a/artifacts/ts/NFTTest.ts
+++ b/artifacts/ts/NFTTest.ts
@@ -65,6 +65,21 @@ export namespace NFTTestTypes {
       ? CallMethodTable[MaybeName]["result"]
       : undefined;
   };
+
+  export interface SignExecuteMethodTable {
+    getTokenUri: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+    getCollectionIndex: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+  }
+  export type SignExecuteMethodParams<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["params"];
+  export type SignExecuteMethodResult<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["result"];
 }
 
 class Factory extends ContractFactory<NFTTestInstance, NFTTestTypes.Fields> {
@@ -138,6 +153,21 @@ export class NFTTestInstance extends ContractInstance {
         params === undefined ? {} : params,
         getContractByCodeHash
       );
+    },
+  };
+
+  call = this.methods;
+
+  transaction = {
+    getTokenUri: async (
+      params: NFTTestTypes.SignExecuteMethodParams<"getTokenUri">
+    ): Promise<NFTTestTypes.SignExecuteMethodResult<"getTokenUri">> => {
+      return signExecuteMethod(NFTTest, this, "getTokenUri", params);
+    },
+    getCollectionIndex: async (
+      params: NFTTestTypes.SignExecuteMethodParams<"getCollectionIndex">
+    ): Promise<NFTTestTypes.SignExecuteMethodResult<"getCollectionIndex">> => {
+      return signExecuteMethod(NFTTest, this, "getCollectionIndex", params);
     },
   };
 

--- a/artifacts/ts/NFTTest.ts
+++ b/artifacts/ts/NFTTest.ts
@@ -31,7 +31,14 @@ import {
 } from "@alephium/web3";
 import { default as NFTTestContractJson } from "../nft/NFTTest.ral.json";
 import { getContractByCodeHash } from "./contracts";
-import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
+import {
+  AddStruct1,
+  AddStruct2,
+  Balances,
+  MapValue,
+  TokenBalance,
+  AllStructs,
+} from "./types";
 
 // Custom types for the contract
 export namespace NFTTestTypes {

--- a/artifacts/ts/OwnerOnly.ts
+++ b/artifacts/ts/OwnerOnly.ts
@@ -41,6 +41,25 @@ export namespace OwnerOnlyTypes {
 
   export type State = ContractState<Fields>;
 
+  export interface CallMethodTable {
+    testOwner: {
+      params: Omit<CallContractParams<{}>, "args">;
+      result: CallContractResult<null>;
+    };
+  }
+  export type CallMethodParams<T extends keyof CallMethodTable> =
+    CallMethodTable[T]["params"];
+  export type CallMethodResult<T extends keyof CallMethodTable> =
+    CallMethodTable[T]["result"];
+  export type MultiCallParams = Partial<{
+    [Name in keyof CallMethodTable]: CallMethodTable[Name]["params"];
+  }>;
+  export type MultiCallResults<T extends MultiCallParams> = {
+    [MaybeName in keyof T]: MaybeName extends keyof CallMethodTable
+      ? CallMethodTable[MaybeName]["result"]
+      : undefined;
+  };
+
   export interface SignExecuteMethodTable {
     testOwner: {
       params: Omit<SignExecuteContractMethodParams<{}>, "args">;
@@ -98,6 +117,22 @@ export class OwnerOnlyInstance extends ContractInstance {
   }
 
   methods = {
+    testOwner: async (
+      params?: OwnerOnlyTypes.CallMethodParams<"testOwner">
+    ): Promise<OwnerOnlyTypes.CallMethodResult<"testOwner">> => {
+      return callMethod(
+        OwnerOnly,
+        this,
+        "testOwner",
+        params === undefined ? {} : params,
+        getContractByCodeHash
+      );
+    },
+  };
+
+  call = this.methods;
+
+  transaction = {
     testOwner: async (
       params: OwnerOnlyTypes.SignExecuteMethodParams<"testOwner">
     ): Promise<OwnerOnlyTypes.SignExecuteMethodResult<"testOwner">> => {

--- a/artifacts/ts/OwnerOnly.ts
+++ b/artifacts/ts/OwnerOnly.ts
@@ -31,7 +31,14 @@ import {
 } from "@alephium/web3";
 import { default as OwnerOnlyContractJson } from "../test/OwnerOnly.ral.json";
 import { getContractByCodeHash } from "./contracts";
-import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
+import {
+  AddStruct1,
+  AddStruct2,
+  Balances,
+  MapValue,
+  TokenBalance,
+  AllStructs,
+} from "./types";
 
 // Custom types for the contract
 export namespace OwnerOnlyTypes {

--- a/artifacts/ts/OwnerOnly.ts
+++ b/artifacts/ts/OwnerOnly.ts
@@ -25,6 +25,9 @@ import {
   getContractEventsCurrentCount,
   TestContractParamsWithoutMaps,
   TestContractResultWithoutMaps,
+  SignExecuteContractMethodParams,
+  SignExecuteScriptTxResult,
+  signExecuteMethod,
 } from "@alephium/web3";
 import { default as OwnerOnlyContractJson } from "../test/OwnerOnly.ral.json";
 import { getContractByCodeHash } from "./contracts";
@@ -37,6 +40,17 @@ export namespace OwnerOnlyTypes {
   };
 
   export type State = ContractState<Fields>;
+
+  export interface SignExecuteMethodTable {
+    testOwner: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+  }
+  export type SignExecuteMethodParams<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["params"];
+  export type SignExecuteMethodResult<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["result"];
 }
 
 class Factory extends ContractFactory<
@@ -82,4 +96,12 @@ export class OwnerOnlyInstance extends ContractInstance {
   async fetchState(): Promise<OwnerOnlyTypes.State> {
     return fetchContractState(OwnerOnly, this);
   }
+
+  methods = {
+    testOwner: async (
+      params: OwnerOnlyTypes.SignExecuteMethodParams<"testOwner">
+    ): Promise<OwnerOnlyTypes.SignExecuteMethodResult<"testOwner">> => {
+      return signExecuteMethod(OwnerOnly, this, "testOwner", params);
+    },
+  };
 }

--- a/artifacts/ts/Sub.ts
+++ b/artifacts/ts/Sub.ts
@@ -31,7 +31,14 @@ import {
 } from "@alephium/web3";
 import { default as SubContractJson } from "../sub/Sub.ral.json";
 import { getContractByCodeHash } from "./contracts";
-import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
+import {
+  AddStruct1,
+  AddStruct2,
+  Balances,
+  MapValue,
+  TokenBalance,
+  AllStructs,
+} from "./types";
 
 // Custom types for the contract
 export namespace SubTypes {

--- a/artifacts/ts/Sub.ts
+++ b/artifacts/ts/Sub.ts
@@ -25,6 +25,9 @@ import {
   getContractEventsCurrentCount,
   TestContractParamsWithoutMaps,
   TestContractResultWithoutMaps,
+  SignExecuteContractMethodParams,
+  SignExecuteScriptTxResult,
+  signExecuteMethod,
 } from "@alephium/web3";
 import { default as SubContractJson } from "../sub/Sub.ral.json";
 import { getContractByCodeHash } from "./contracts";

--- a/artifacts/ts/Sub.ts
+++ b/artifacts/ts/Sub.ts
@@ -61,6 +61,17 @@ export namespace SubTypes {
       ? CallMethodTable[MaybeName]["result"]
       : undefined;
   };
+
+  export interface SignExecuteMethodTable {
+    sub: {
+      params: SignExecuteContractMethodParams<{ array: [bigint, bigint] }>;
+      result: SignExecuteScriptTxResult;
+    };
+  }
+  export type SignExecuteMethodParams<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["params"];
+  export type SignExecuteMethodResult<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["result"];
 }
 
 class Factory extends ContractFactory<SubInstance, SubTypes.Fields> {
@@ -128,6 +139,16 @@ export class SubInstance extends ContractInstance {
       params: SubTypes.CallMethodParams<"sub">
     ): Promise<SubTypes.CallMethodResult<"sub">> => {
       return callMethod(Sub, this, "sub", params, getContractByCodeHash);
+    },
+  };
+
+  call = this.methods;
+
+  transaction = {
+    sub: async (
+      params: SubTypes.SignExecuteMethodParams<"sub">
+    ): Promise<SubTypes.SignExecuteMethodResult<"sub">> => {
+      return signExecuteMethod(Sub, this, "sub", params);
     },
   };
 

--- a/artifacts/ts/TokenTest.ts
+++ b/artifacts/ts/TokenTest.ts
@@ -31,7 +31,14 @@ import {
 } from "@alephium/web3";
 import { default as TokenTestContractJson } from "../token/TokenTest.ral.json";
 import { getContractByCodeHash } from "./contracts";
-import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
+import {
+  AddStruct1,
+  AddStruct2,
+  Balances,
+  MapValue,
+  TokenBalance,
+  AllStructs,
+} from "./types";
 
 // Custom types for the contract
 export namespace TokenTestTypes {

--- a/artifacts/ts/TokenTest.ts
+++ b/artifacts/ts/TokenTest.ts
@@ -25,6 +25,9 @@ import {
   getContractEventsCurrentCount,
   TestContractParamsWithoutMaps,
   TestContractResultWithoutMaps,
+  SignExecuteContractMethodParams,
+  SignExecuteScriptTxResult,
+  signExecuteMethod,
 } from "@alephium/web3";
 import { default as TokenTestContractJson } from "../token/TokenTest.ral.json";
 import { getContractByCodeHash } from "./contracts";

--- a/artifacts/ts/TokenTest.ts
+++ b/artifacts/ts/TokenTest.ts
@@ -74,6 +74,29 @@ export namespace TokenTestTypes {
       ? CallMethodTable[MaybeName]["result"]
       : undefined;
   };
+
+  export interface SignExecuteMethodTable {
+    getSymbol: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+    getName: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+    getDecimals: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+    getTotalSupply: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+  }
+  export type SignExecuteMethodParams<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["params"];
+  export type SignExecuteMethodResult<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["result"];
 }
 
 class Factory extends ContractFactory<
@@ -188,6 +211,31 @@ export class TokenTestInstance extends ContractInstance {
         params === undefined ? {} : params,
         getContractByCodeHash
       );
+    },
+  };
+
+  call = this.methods;
+
+  transaction = {
+    getSymbol: async (
+      params: TokenTestTypes.SignExecuteMethodParams<"getSymbol">
+    ): Promise<TokenTestTypes.SignExecuteMethodResult<"getSymbol">> => {
+      return signExecuteMethod(TokenTest, this, "getSymbol", params);
+    },
+    getName: async (
+      params: TokenTestTypes.SignExecuteMethodParams<"getName">
+    ): Promise<TokenTestTypes.SignExecuteMethodResult<"getName">> => {
+      return signExecuteMethod(TokenTest, this, "getName", params);
+    },
+    getDecimals: async (
+      params: TokenTestTypes.SignExecuteMethodParams<"getDecimals">
+    ): Promise<TokenTestTypes.SignExecuteMethodResult<"getDecimals">> => {
+      return signExecuteMethod(TokenTest, this, "getDecimals", params);
+    },
+    getTotalSupply: async (
+      params: TokenTestTypes.SignExecuteMethodParams<"getTotalSupply">
+    ): Promise<TokenTestTypes.SignExecuteMethodResult<"getTotalSupply">> => {
+      return signExecuteMethod(TokenTest, this, "getTotalSupply", params);
     },
   };
 

--- a/artifacts/ts/UserAccount.ts
+++ b/artifacts/ts/UserAccount.ts
@@ -25,6 +25,9 @@ import {
   getContractEventsCurrentCount,
   TestContractParamsWithoutMaps,
   TestContractResultWithoutMaps,
+  SignExecuteContractMethodParams,
+  SignExecuteScriptTxResult,
+  signExecuteMethod,
 } from "@alephium/web3";
 import { default as UserAccountContractJson } from "../test/UserAccount.ral.json";
 import { getContractByCodeHash } from "./contracts";
@@ -59,6 +62,23 @@ export namespace UserAccountTypes {
       ? CallMethodTable[MaybeName]["result"]
       : undefined;
   };
+
+  export interface SignExecuteMethodTable {
+    updateBalance: {
+      params: SignExecuteContractMethodParams<{
+        tokens: [TokenBalance, TokenBalance];
+      }>;
+      result: SignExecuteScriptTxResult;
+    };
+    updateAddress: {
+      params: SignExecuteContractMethodParams<{ newAddress: Address }>;
+      result: SignExecuteScriptTxResult;
+    };
+  }
+  export type SignExecuteMethodParams<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["params"];
+  export type SignExecuteMethodResult<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["result"];
 }
 
 class Factory extends ContractFactory<
@@ -122,6 +142,16 @@ export class UserAccountInstance extends ContractInstance {
   }
 
   methods = {
+    updateBalance: async (
+      params: UserAccountTypes.SignExecuteMethodParams<"updateBalance">
+    ): Promise<UserAccountTypes.SignExecuteMethodResult<"updateBalance">> => {
+      return signExecuteMethod(UserAccount, this, "updateBalance", params);
+    },
+    updateAddress: async (
+      params: UserAccountTypes.SignExecuteMethodParams<"updateAddress">
+    ): Promise<UserAccountTypes.SignExecuteMethodResult<"updateAddress">> => {
+      return signExecuteMethod(UserAccount, this, "updateAddress", params);
+    },
     getBalances: async (
       params?: UserAccountTypes.CallMethodParams<"getBalances">
     ): Promise<UserAccountTypes.CallMethodResult<"getBalances">> => {

--- a/artifacts/ts/UserAccount.ts
+++ b/artifacts/ts/UserAccount.ts
@@ -31,7 +31,14 @@ import {
 } from "@alephium/web3";
 import { default as UserAccountContractJson } from "../test/UserAccount.ral.json";
 import { getContractByCodeHash } from "./contracts";
-import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
+import {
+  AddStruct1,
+  AddStruct2,
+  Balances,
+  MapValue,
+  TokenBalance,
+  AllStructs,
+} from "./types";
 
 // Custom types for the contract
 export namespace UserAccountTypes {

--- a/artifacts/ts/UserAccount.ts
+++ b/artifacts/ts/UserAccount.ts
@@ -45,6 +45,14 @@ export namespace UserAccountTypes {
   export type State = ContractState<Fields>;
 
   export interface CallMethodTable {
+    updateBalance: {
+      params: CallContractParams<{ tokens: [TokenBalance, TokenBalance] }>;
+      result: CallContractResult<null>;
+    };
+    updateAddress: {
+      params: CallContractParams<{ newAddress: Address }>;
+      result: CallContractResult<null>;
+    };
     getBalances: {
       params: Omit<CallContractParams<{}>, "args">;
       result: CallContractResult<Balances>;
@@ -72,6 +80,10 @@ export namespace UserAccountTypes {
     };
     updateAddress: {
       params: SignExecuteContractMethodParams<{ newAddress: Address }>;
+      result: SignExecuteScriptTxResult;
+    };
+    getBalances: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
       result: SignExecuteScriptTxResult;
     };
   }
@@ -143,14 +155,26 @@ export class UserAccountInstance extends ContractInstance {
 
   methods = {
     updateBalance: async (
-      params: UserAccountTypes.SignExecuteMethodParams<"updateBalance">
-    ): Promise<UserAccountTypes.SignExecuteMethodResult<"updateBalance">> => {
-      return signExecuteMethod(UserAccount, this, "updateBalance", params);
+      params: UserAccountTypes.CallMethodParams<"updateBalance">
+    ): Promise<UserAccountTypes.CallMethodResult<"updateBalance">> => {
+      return callMethod(
+        UserAccount,
+        this,
+        "updateBalance",
+        params,
+        getContractByCodeHash
+      );
     },
     updateAddress: async (
-      params: UserAccountTypes.SignExecuteMethodParams<"updateAddress">
-    ): Promise<UserAccountTypes.SignExecuteMethodResult<"updateAddress">> => {
-      return signExecuteMethod(UserAccount, this, "updateAddress", params);
+      params: UserAccountTypes.CallMethodParams<"updateAddress">
+    ): Promise<UserAccountTypes.CallMethodResult<"updateAddress">> => {
+      return callMethod(
+        UserAccount,
+        this,
+        "updateAddress",
+        params,
+        getContractByCodeHash
+      );
     },
     getBalances: async (
       params?: UserAccountTypes.CallMethodParams<"getBalances">
@@ -162,6 +186,26 @@ export class UserAccountInstance extends ContractInstance {
         params === undefined ? {} : params,
         getContractByCodeHash
       );
+    },
+  };
+
+  call = this.methods;
+
+  transaction = {
+    updateBalance: async (
+      params: UserAccountTypes.SignExecuteMethodParams<"updateBalance">
+    ): Promise<UserAccountTypes.SignExecuteMethodResult<"updateBalance">> => {
+      return signExecuteMethod(UserAccount, this, "updateBalance", params);
+    },
+    updateAddress: async (
+      params: UserAccountTypes.SignExecuteMethodParams<"updateAddress">
+    ): Promise<UserAccountTypes.SignExecuteMethodResult<"updateAddress">> => {
+      return signExecuteMethod(UserAccount, this, "updateAddress", params);
+    },
+    getBalances: async (
+      params: UserAccountTypes.SignExecuteMethodParams<"getBalances">
+    ): Promise<UserAccountTypes.SignExecuteMethodResult<"getBalances">> => {
+      return signExecuteMethod(UserAccount, this, "getBalances", params);
     },
   };
 

--- a/artifacts/ts/Warnings.ts
+++ b/artifacts/ts/Warnings.ts
@@ -31,7 +31,14 @@ import {
 } from "@alephium/web3";
 import { default as WarningsContractJson } from "../test/Warnings.ral.json";
 import { getContractByCodeHash } from "./contracts";
-import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
+import {
+  AddStruct1,
+  AddStruct2,
+  Balances,
+  MapValue,
+  TokenBalance,
+  AllStructs,
+} from "./types";
 
 // Custom types for the contract
 export namespace WarningsTypes {

--- a/artifacts/ts/Warnings.ts
+++ b/artifacts/ts/Warnings.ts
@@ -25,6 +25,9 @@ import {
   getContractEventsCurrentCount,
   TestContractParamsWithoutMaps,
   TestContractResultWithoutMaps,
+  SignExecuteContractMethodParams,
+  SignExecuteScriptTxResult,
+  signExecuteMethod,
 } from "@alephium/web3";
 import { default as WarningsContractJson } from "../test/Warnings.ral.json";
 import { getContractByCodeHash } from "./contracts";
@@ -38,6 +41,17 @@ export namespace WarningsTypes {
   };
 
   export type State = ContractState<Fields>;
+
+  export interface SignExecuteMethodTable {
+    foo: {
+      params: SignExecuteContractMethodParams<{ x: bigint; y: bigint }>;
+      result: SignExecuteScriptTxResult;
+    };
+  }
+  export type SignExecuteMethodParams<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["params"];
+  export type SignExecuteMethodResult<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["result"];
 }
 
 class Factory extends ContractFactory<WarningsInstance, WarningsTypes.Fields> {
@@ -82,4 +96,12 @@ export class WarningsInstance extends ContractInstance {
   async fetchState(): Promise<WarningsTypes.State> {
     return fetchContractState(Warnings, this);
   }
+
+  methods = {
+    foo: async (
+      params: WarningsTypes.SignExecuteMethodParams<"foo">
+    ): Promise<WarningsTypes.SignExecuteMethodResult<"foo">> => {
+      return signExecuteMethod(Warnings, this, "foo", params);
+    },
+  };
 }

--- a/artifacts/ts/Warnings.ts
+++ b/artifacts/ts/Warnings.ts
@@ -42,6 +42,25 @@ export namespace WarningsTypes {
 
   export type State = ContractState<Fields>;
 
+  export interface CallMethodTable {
+    foo: {
+      params: CallContractParams<{ x: bigint; y: bigint }>;
+      result: CallContractResult<null>;
+    };
+  }
+  export type CallMethodParams<T extends keyof CallMethodTable> =
+    CallMethodTable[T]["params"];
+  export type CallMethodResult<T extends keyof CallMethodTable> =
+    CallMethodTable[T]["result"];
+  export type MultiCallParams = Partial<{
+    [Name in keyof CallMethodTable]: CallMethodTable[Name]["params"];
+  }>;
+  export type MultiCallResults<T extends MultiCallParams> = {
+    [MaybeName in keyof T]: MaybeName extends keyof CallMethodTable
+      ? CallMethodTable[MaybeName]["result"]
+      : undefined;
+  };
+
   export interface SignExecuteMethodTable {
     foo: {
       params: SignExecuteContractMethodParams<{ x: bigint; y: bigint }>;
@@ -98,6 +117,16 @@ export class WarningsInstance extends ContractInstance {
   }
 
   methods = {
+    foo: async (
+      params: WarningsTypes.CallMethodParams<"foo">
+    ): Promise<WarningsTypes.CallMethodResult<"foo">> => {
+      return callMethod(Warnings, this, "foo", params, getContractByCodeHash);
+    },
+  };
+
+  call = this.methods;
+
+  transaction = {
     foo: async (
       params: WarningsTypes.SignExecuteMethodParams<"foo">
     ): Promise<WarningsTypes.SignExecuteMethodResult<"foo">> => {

--- a/artifacts/ts/WrongNFTTest.ts
+++ b/artifacts/ts/WrongNFTTest.ts
@@ -65,6 +65,21 @@ export namespace WrongNFTTestTypes {
       ? CallMethodTable[MaybeName]["result"]
       : undefined;
   };
+
+  export interface SignExecuteMethodTable {
+    getTokenUri: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+    getCollectionIndex: {
+      params: Omit<SignExecuteContractMethodParams<{}>, "args">;
+      result: SignExecuteScriptTxResult;
+    };
+  }
+  export type SignExecuteMethodParams<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["params"];
+  export type SignExecuteMethodResult<T extends keyof SignExecuteMethodTable> =
+    SignExecuteMethodTable[T]["result"];
 }
 
 class Factory extends ContractFactory<
@@ -140,6 +155,28 @@ export class WrongNFTTestInstance extends ContractInstance {
         "getCollectionIndex",
         params === undefined ? {} : params,
         getContractByCodeHash
+      );
+    },
+  };
+
+  call = this.methods;
+
+  transaction = {
+    getTokenUri: async (
+      params: WrongNFTTestTypes.SignExecuteMethodParams<"getTokenUri">
+    ): Promise<WrongNFTTestTypes.SignExecuteMethodResult<"getTokenUri">> => {
+      return signExecuteMethod(WrongNFTTest, this, "getTokenUri", params);
+    },
+    getCollectionIndex: async (
+      params: WrongNFTTestTypes.SignExecuteMethodParams<"getCollectionIndex">
+    ): Promise<
+      WrongNFTTestTypes.SignExecuteMethodResult<"getCollectionIndex">
+    > => {
+      return signExecuteMethod(
+        WrongNFTTest,
+        this,
+        "getCollectionIndex",
+        params
       );
     },
   };

--- a/artifacts/ts/WrongNFTTest.ts
+++ b/artifacts/ts/WrongNFTTest.ts
@@ -31,7 +31,14 @@ import {
 } from "@alephium/web3";
 import { default as WrongNFTTestContractJson } from "../nft/WrongNFTTest.ral.json";
 import { getContractByCodeHash } from "./contracts";
-import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
+import {
+  AddStruct1,
+  AddStruct2,
+  Balances,
+  MapValue,
+  TokenBalance,
+  AllStructs,
+} from "./types";
 
 // Custom types for the contract
 export namespace WrongNFTTestTypes {

--- a/artifacts/ts/WrongNFTTest.ts
+++ b/artifacts/ts/WrongNFTTest.ts
@@ -25,6 +25,9 @@ import {
   getContractEventsCurrentCount,
   TestContractParamsWithoutMaps,
   TestContractResultWithoutMaps,
+  SignExecuteContractMethodParams,
+  SignExecuteScriptTxResult,
+  signExecuteMethod,
 } from "@alephium/web3";
 import { default as WrongNFTTestContractJson } from "../nft/WrongNFTTest.ral.json";
 import { getContractByCodeHash } from "./contracts";

--- a/artifacts/ts/scripts.ts
+++ b/artifacts/ts/scripts.ts
@@ -11,10 +11,10 @@ import {
   SignerProvider,
   HexString,
 } from "@alephium/web3";
+import { default as AddMainScriptJson } from "../add/AddMain.ral.json";
 import { default as DestroyAddScriptJson } from "../add/DestroyAdd.ral.json";
 import { default as GreeterMainScriptJson } from "../greeter/GreeterMain.ral.json";
 import { default as InsertIntoMapScriptJson } from "../test/InsertIntoMap.ral.json";
-import { default as MainScriptJson } from "../add/Main.ral.json";
 import { default as MintNFTTestScriptJson } from "../nft/MintNFTTest.ral.json";
 import { default as RemoveFromMapScriptJson } from "../test/RemoveFromMap.ral.json";
 import { default as TemplateArrayVarScriptJson } from "../test/TemplateArrayVar.ral.json";
@@ -23,6 +23,11 @@ import { default as UpdateMapValueScriptJson } from "../test/UpdateMapValue.ral.
 import { default as UpdateUserAccountScriptJson } from "../test/UpdateUserAccount.ral.json";
 import { default as WithdrawNFTCollectionTestScriptJson } from "../nft/WithdrawNFTCollectionTest.ral.json";
 import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
+
+export const AddMain = new ExecutableScript<{
+  add: HexString;
+  array: [bigint, bigint];
+}>(Script.fromJson(AddMainScriptJson, "", AllStructs));
 
 export const DestroyAdd = new ExecutableScript<{
   add: HexString;
@@ -38,10 +43,6 @@ export const InsertIntoMap = new ExecutableScript<{
   from: Address;
   value: MapValue;
 }>(Script.fromJson(InsertIntoMapScriptJson, "", AllStructs));
-
-export const Main = new ExecutableScript<{ addContractId: HexString }>(
-  Script.fromJson(MainScriptJson, "", AllStructs)
-);
 
 export const MintNFTTest = new ExecutableScript<{
   nftCollectionContractId: HexString;

--- a/artifacts/ts/scripts.ts
+++ b/artifacts/ts/scripts.ts
@@ -22,7 +22,14 @@ import { default as TestAssertScriptJson } from "../test/TestAssert.ral.json";
 import { default as UpdateMapValueScriptJson } from "../test/UpdateMapValue.ral.json";
 import { default as UpdateUserAccountScriptJson } from "../test/UpdateUserAccount.ral.json";
 import { default as WithdrawNFTCollectionTestScriptJson } from "../nft/WithdrawNFTCollectionTest.ral.json";
-import { Balances, MapValue, TokenBalance, AllStructs } from "./types";
+import {
+  AddStruct1,
+  AddStruct2,
+  Balances,
+  MapValue,
+  TokenBalance,
+  AllStructs,
+} from "./types";
 
 export const AddMain = new ExecutableScript<{
   add: HexString;

--- a/artifacts/ts/types.ts
+++ b/artifacts/ts/types.ts
@@ -5,6 +5,14 @@
 import { Address, HexString, Val, Struct } from "@alephium/web3";
 import { default as allStructsJson } from "../structs.ral.json";
 export const AllStructs = allStructsJson.map((json) => Struct.fromJson(json));
+export interface AddStruct1 extends Record<string, Val> {
+  a: bigint;
+  b: [AddStruct2, AddStruct2];
+}
+export interface AddStruct2 extends Record<string, Val> {
+  a: bigint;
+  b: [bigint, bigint];
+}
 export interface Balances extends Record<string, Val> {
   totalAmount: bigint;
   tokens: [TokenBalance, TokenBalance];

--- a/contracts/add/add.ral
+++ b/contracts/add/add.ral
@@ -27,7 +27,6 @@ Contract Add(sub: Sub, mut result : U256) {
     }
 }
 
-TxScript Main(addContractId: ByteVec) {
-    let add = Add(addContractId)
-    add.add([2, 1])
+TxScript AddMain(add: Add, array: [U256; 2]) {
+    add.add(array)
 }

--- a/contracts/add/add.ral
+++ b/contracts/add/add.ral
@@ -35,6 +35,13 @@ Contract Add(sub: Sub, mut result : U256) {
         copyCreateSubContract!{payer -> ALPH: minimalContractDeposit!()}(path, subContractId, immFields, mutFields)
     }
 
+    @using(preapprovedAssets = true, assetsInContract = true)
+    pub fn createSubContractAndTransfer(a: U256, path: ByteVec, subContractId: ByteVec, payer: Address) -> () {
+        let (immFields, mutFields) = Sub.encodeFields!(a)
+        transferTokenToSelf!(payer, subContractId, 200)
+        copyCreateSubContract!{payer -> ALPH: minimalContractDeposit!()}(path, subContractId, immFields, mutFields)
+    }
+
     @using(checkExternalCaller = false, assetsInContract = true)
     pub fn destroy(caller: Address) -> () {
         destroySelf!(caller)

--- a/contracts/add/add.ral
+++ b/contracts/add/add.ral
@@ -1,9 +1,23 @@
+struct AddStruct1 {
+    a: U256,
+    b: [AddStruct2; 2]
+}
+
+struct AddStruct2 {
+    a: U256,
+    b: [U256; 2]
+}
+
 Contract Add(sub: Sub, mut result : U256) {
     event Add(x: U256, y: U256)
     event Add1(a: U256, b: U256)
 
     pub fn add(array: [U256; 2]) -> ([U256; 2]) {
         return addPrivate(array)
+    }
+
+    pub fn add2(array1: [U256; 2], address: Address, array2: [U256; 2], addS: AddStruct1) -> ([U256; 2]) {
+        return addPrivate(array1)
     }
 
     @using(updateFields = true)

--- a/packages/cli/src/codegen.ts
+++ b/packages/cli/src/codegen.ts
@@ -96,15 +96,6 @@ function formatParameters(fieldsSig: { names: string[]; types: string[] }): stri
 }
 
 function genCallMethod(contractName: string, functionSig: node.FunctionSig): string {
-  //  if (functionSig.returnTypes.length === 0) {
-  //    const retType = `${contractName}Types.SignExecuteMethodResult<'${functionSig.name}'>`
-  //    const params = `params: ${contractName}Types.SignExecuteMethodParams<'${functionSig.name}'>`
-  //    return `
-  //    ${functionSig.name}: async (${params}): Promise<${retType}> => {
-  //      return signExecuteMethod(${contractName}, this, "${functionSig.name}", params)
-  //    }
-  //  `
-  //  } else {
   const retType = `${contractName}Types.CallMethodResult<'${functionSig.name}'>`
   const funcHasArgs = functionSig.paramNames.length > 0
   const params = `params${funcHasArgs ? '' : '?'}: ${contractName}Types.CallMethodParams<'${functionSig.name}'>`
@@ -114,7 +105,6 @@ function genCallMethod(contractName: string, functionSig: node.FunctionSig): str
       return callMethod(${contractName}, this, "${functionSig.name}", ${callParams}, getContractByCodeHash)
     }
   `
-  //  }
 }
 
 function genCallMethods(contract: Contract): string {

--- a/packages/web3/src/api/utils.test.ts
+++ b/packages/web3/src/api/utils.test.ts
@@ -16,6 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { enableDebugMode, groupOfAddress } from '..'
 import { ONE_ALPH } from '../constants'
 import { NodeProvider, isBalanceEqual, node } from './index'
 

--- a/packages/web3/src/contract/contract.ts
+++ b/packages/web3/src/contract/contract.ts
@@ -2306,7 +2306,7 @@ export async function signExecuteMethod<I extends ContractInstance, F extends Fi
 
 function encodeBytecodeTemplate(methodIndex: number, functionSig: FunctionSig): string {
   const numberOfMethods = '01'
-  const isPublic = functionSig.isPublic ? '01' : '00'
+  const isPublic = '01'
   const modifier = '03'
   const argsLength = '00'
   const localsLength = '00'

--- a/test/contract.test.ts
+++ b/test/contract.test.ts
@@ -523,4 +523,18 @@ describe('contract', function () {
     const exist1 = (await mapTest.methods.contains({ args: { key: signer.address } })).returns
     expect(exist1).toEqual(false)
   })
+
+  it('should test sign execute method', async () => {
+    const sub = await Sub.deploy(signer, { initialFields: { result: 0n } })
+    const add = (await Add.deploy(signer, { initialFields: { sub: sub.contractInstance.contractId, result: 0n } }))
+      .contractInstance
+    const caller = (await signer.getSelectedAccount()).address
+    const provider = web3.getCurrentNodeProvider()
+
+    const state = await provider.contracts.getContractsAddressState(add.address)
+    expect(state).toBeDefined()
+
+    await add.methods.destroy({ args: { caller: caller }, signer })
+    await expect(provider.contracts.getContractsAddressState(add.address)).rejects.toThrow(Error)
+  })
 })

--- a/test/contract.test.ts
+++ b/test/contract.test.ts
@@ -42,7 +42,7 @@ import { Greeter } from '../artifacts/ts/Greeter'
 import {
   GreeterMain,
   InsertIntoMap,
-  Main,
+  AddMain,
   RemoveFromMap,
   TemplateArrayVar,
   TestAssert,
@@ -155,7 +155,7 @@ describe('contract', function () {
     expect(addContractState0.address).toEqual(add.address)
     expect(addContractState0.contractId).toEqual(add.contractId)
 
-    const mainScriptTx = await Main.execute(signer, { initialFields: { addContractId: add.contractId } })
+    const mainScriptTx = await AddMain.execute(signer, { initialFields: { add: add.contractId, array: [2n, 1n] } })
     expect(mainScriptTx.groupIndex).toEqual(signerGroup)
 
     // Check state for add/sub after main script is executed
@@ -256,7 +256,7 @@ describe('contract', function () {
   it('should load contract from json', () => {
     loadContract('./artifacts/add/Add.ral.json')
     loadContract('./artifacts/sub/Sub.ral.json')
-    loadScript('./artifacts/add/Main.ral.json')
+    loadScript('./artifacts/add/AddMain.ral.json')
 
     loadContract('./artifacts/greeter/Greeter.ral.json')
     loadScript('./artifacts/greeter/GreeterMain.ral.json')

--- a/test/contract.test.ts
+++ b/test/contract.test.ts
@@ -245,7 +245,7 @@ describe('contract', function () {
 
   it('should load source files by order', async () => {
     const sourceFiles = await Project['loadSourceFiles']('.', './contracts') // `loadSourceFiles` is a private method
-    expect(sourceFiles.length).toEqual(44)
+    expect(sourceFiles.length).toEqual(46)
     sourceFiles.slice(0, 23).forEach((c) => expect(c.type).toEqual(0)) // contracts
     sourceFiles.slice(23, 34).forEach((s) => expect(s.type).toEqual(1)) // scripts
     sourceFiles.slice(34, 36).forEach((i) => expect(i.type).toEqual(2)) // abstract class
@@ -536,5 +536,43 @@ describe('contract', function () {
 
     await add.transaction.destroy({ args: { caller: caller }, signer })
     await expect(provider.contracts.getContractsAddressState(add.address)).rejects.toThrow(Error)
+  })
+
+  it('should test sign execute method with array arguments', async () => {
+    const sub = await Sub.deploy(signer, { initialFields: { result: 0n } })
+    const add = (await Add.deploy(signer, { initialFields: { sub: sub.contractInstance.contractId, result: 0n } }))
+      .contractInstance
+    const provider = web3.getCurrentNodeProvider()
+
+    const state = await provider.contracts.getContractsAddressState(add.address)
+    expect(state).toBeDefined()
+
+    await add.transaction.add({ args: { array: [2n, 1n] }, signer })
+  })
+
+  it('should test sign execute method with struct arguments', async () => {
+    const sub = await Sub.deploy(signer, { initialFields: { result: 0n } })
+    const add = (await Add.deploy(signer, { initialFields: { sub: sub.contractInstance.contractId, result: 0n } }))
+      .contractInstance
+    const provider = web3.getCurrentNodeProvider()
+
+    const state = await provider.contracts.getContractsAddressState(add.address)
+    expect(state).toBeDefined()
+
+    await add.transaction.add2({
+      args: {
+        array1: [2n, 1n],
+        address: signer.address,
+        array2: [2n, 1n],
+        addS: {
+          a: 1n,
+          b: [
+            { a: 1n, b: [2n, 1n] },
+            { a: 1n, b: [2n, 1n] }
+          ]
+        }
+      },
+      signer
+    })
   })
 })

--- a/test/contract.test.ts
+++ b/test/contract.test.ts
@@ -510,7 +510,7 @@ describe('contract', function () {
     const exist0 = (await mapTest.methods.contains({ args: { key: signer.address } })).returns
     expect(exist0).toEqual(true)
 
-    const value = (await mapTest.methods.get({ args: { key: signer.address } })).returns
+    const value = (await mapTest.call.get({ args: { key: signer.address } })).returns
     expect(value).toEqual({ id: 1n, balance: 10n })
 
     await RemoveFromMap.execute(signer, {
@@ -520,11 +520,11 @@ describe('contract', function () {
       }
     })
 
-    const exist1 = (await mapTest.methods.contains({ args: { key: signer.address } })).returns
+    const exist1 = (await mapTest.call.contains({ args: { key: signer.address } })).returns
     expect(exist1).toEqual(false)
   })
 
-  it('should test sign execute method', async () => {
+  it('should test sign execute method with primitive arguments', async () => {
     const sub = await Sub.deploy(signer, { initialFields: { result: 0n } })
     const add = (await Add.deploy(signer, { initialFields: { sub: sub.contractInstance.contractId, result: 0n } }))
       .contractInstance
@@ -534,7 +534,7 @@ describe('contract', function () {
     const state = await provider.contracts.getContractsAddressState(add.address)
     expect(state).toBeDefined()
 
-    await add.methods.destroy({ args: { caller: caller }, signer })
+    await add.transaction.destroy({ args: { caller: caller }, signer })
     await expect(provider.contracts.getContractsAddressState(add.address)).rejects.toThrow(Error)
   })
 })

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -27,7 +27,7 @@ import { EventSubscribeOptions, sleep } from '../packages/web3'
 import { web3 } from '../packages/web3'
 import { Sub } from '../artifacts/ts/Sub'
 import { Add, AddTypes, AddInstance } from '../artifacts/ts/Add'
-import { Main, DestroyAdd } from '../artifacts/ts/scripts'
+import { AddMain, DestroyAdd } from '../artifacts/ts/scripts'
 import { CreateContractEventAddresses, DestroyContractEventAddresses } from '../packages/web3'
 import { ContractCreatedEvent, subscribeContractCreatedEvent } from '../packages/web3'
 import { ContractDestroyedEvent, subscribeContractDestroyedEvent } from '../packages/web3'
@@ -80,7 +80,7 @@ describe('events', function () {
     const subscribeOptions = createSubscribeOptions(addEvents)
     const subscription = add.subscribeAddEvent(subscribeOptions)
     for (let i = 0; i < 3; i++) {
-      await Main.execute(signer, { initialFields: { addContractId: add.contractId } })
+      await AddMain.execute(signer, { initialFields: { add: add.contractId, array: [2n, 1n] } })
     }
     await sleep(3000)
 
@@ -104,7 +104,7 @@ describe('events', function () {
     const subscribeOptions = createSubscribeOptions(addEvents)
     const subscription = add.subscribeAllEvents(subscribeOptions)
     for (let i = 0; i < 3; i++) {
-      await Main.execute(signer, { initialFields: { addContractId: add.contractId } })
+      await AddMain.execute(signer, { initialFields: { add: add.contractId, array: [2n, 1n] } })
     }
     await sleep(3000)
 
@@ -143,7 +143,7 @@ describe('events', function () {
     const addEvents: Array<AddTypes.AddEvent> = []
     const subscribeOptions = createSubscribeOptions(addEvents)
     const subscription = add.subscribeAddEvent(subscribeOptions)
-    const scriptTx0 = await Main.execute(signer, { initialFields: { addContractId: add.contractId } })
+    const scriptTx0 = await AddMain.execute(signer, { initialFields: { add: add.contractId, array: [2n, 1n] } })
     await sleep(1500)
     expect(eventCount).toEqual(1)
     subscription.unsubscribe()
@@ -154,7 +154,7 @@ describe('events', function () {
     expect(addEvents[0].fields.y).toEqual(1n)
     expect(subscription.currentEventCount()).toEqual(addEvents.length)
 
-    await Main.execute(signer, { initialFields: { addContractId: add.contractId } })
+    await AddMain.execute(signer, { initialFields: { add: add.contractId, array: [2n, 1n] } })
     await sleep(1500)
     expect(eventCount).toEqual(1)
     expect(addEvents.length).toEqual(1)

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -24,7 +24,7 @@ import { web3 } from '../packages/web3'
 import { TxStatus } from '../packages/web3'
 import { PrivateKeyWallet } from '@alephium/web3-wallet'
 import { ONE_ALPH } from '../packages/web3/src'
-import { Add, Sub, Main } from '../artifacts/ts'
+import { Add, Sub, AddMain } from '../artifacts/ts'
 import { getSigner } from '@alephium/web3-test'
 
 describe('transactions', function () {
@@ -102,7 +102,7 @@ describe('transactions', function () {
     ).contractInstance
     expect((await addInstance.fetchState()).fields.result).toBe(0n)
 
-    await Main.execute(schnorrSigner, { initialFields: { addContractId: addInstance.contractId } })
+    await AddMain.execute(schnorrSigner, { initialFields: { add: addInstance.contractId, array: [2n, 1n] } })
     expect((await addInstance.fetchState()).fields.result).toBe(3n)
   })
 })


### PR DESCRIPTION
Support simple transaction method call without explicit `TxScript`, example:

- Primitive function parameters:
```
await add.transaction.destroy({ args: { caller: caller }, signer })
```

- Arrays and struct:
```
    await add.transaction.add2({
      args: {
        array1: [2n, 1n],
        address: signer.address,
        array2: [2n, 1n],
        addS: {
          a: 1n,
          b: [
            { a: 1n, b: [2n, 1n] },
            { a: 1n, b: [2n, 1n] }
          ]
        }
      },
      signer
    })
```

- asset transfer
```
add.transaction.createSubContractAndTransfer({
      args: {
        a: 1n,
        path: stringToHex('test-path'),
        subContractId: sub.contractInstance.contractId,
        payer: signerAddress
      },
      signer,
      attoAlphAmount: ONE_ALPH * 2n,
      tokens: [{ id: sub.contractInstance.contractId, amount: 200n }],
      approve: {
        attoAlphAmount: ONE_ALPH,
        tokens: [{ id: sub.contractInstance.contractId, amount: 200n }]
      }
    })
```