### PR TITLE
Update sdk to support rhone upgrade

### DIFF
--- a/.project.json
+++ b/.project.json
@@ -138,28 +138,28 @@
     },
     "IFungibleToken": {
       "sourceFile": "../packages/web3/std/fungible_token_interface.ral",
-      "sourceCodeHash": "6809cb06fb20fa7edf529461998beeebd12b1636d439612cca2f84214dbf4a20",
+      "sourceCodeHash": "62910bf11e1eeb6cb2fd468626ff606a9b06306b2b81590c3b10f6deb5966bde",
       "bytecodeDebugPatch": "",
       "codeHashDebug": "",
       "warnings": []
     },
     "INFT": {
       "sourceFile": "../packages/web3/std/nft_interface.ral",
-      "sourceCodeHash": "7f7514adf9fee057049d1c162701725b3377c01a0a102e6f0f5cf747039926b6",
+      "sourceCodeHash": "acff0211f936d18d3f4a01ddd8f4fe8fbdf0dba9e8b9204b233a48cba1c80d8b",
       "bytecodeDebugPatch": "",
       "codeHashDebug": "",
       "warnings": []
     },
     "INFTCollection": {
       "sourceFile": "../packages/web3/std/nft_collection_interface.ral",
-      "sourceCodeHash": "06648d34b65081500e038a943eb81d66301b43252b447d8cb96e0c8f2095edf8",
+      "sourceCodeHash": "9b199426ea89c188ce858b48ab809f13b9fc1ed0d64ca91e3d600eda8fbf6c42",
       "bytecodeDebugPatch": "",
       "codeHashDebug": "",
       "warnings": []
     },
     "INFTCollectionWithRoyalty": {
       "sourceFile": "../packages/web3/std/nft_collection_with_royalty_interface.ral",
-      "sourceCodeHash": "9f325c739267074d442f0da4536fd68baeb9571ef220e29cca6bc173af24b232",
+      "sourceCodeHash": "293aad668909a21df80183c9296f3d1a8edb76a43faa2cbf395a766d1879cdc6",
       "bytecodeDebugPatch": "",
       "codeHashDebug": "",
       "warnings": []

--- a/artifacts/add/Add.ral.json
+++ b/artifacts/add/Add.ral.json
@@ -44,9 +44,6 @@
   "functions": [
     {
       "name": "add",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [
         "array"
       ],
@@ -62,9 +59,6 @@
     },
     {
       "name": "addPrivate",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": false,
       "paramNames": [
         "array"
       ],
@@ -80,9 +74,6 @@
     },
     {
       "name": "createSubContract",
-      "usePreapprovedAssets": true,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [
         "a",
         "path",
@@ -105,9 +96,6 @@
     },
     {
       "name": "destroy",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": true,
-      "isPublic": true,
       "paramNames": [
         "caller"
       ],

--- a/artifacts/add/DestroyAdd.ral.json
+++ b/artifacts/add/DestroyAdd.ral.json
@@ -19,9 +19,6 @@
   "functions": [
     {
       "name": "main",
-      "usePreapprovedAssets": true,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/add/Main.ral.json
+++ b/artifacts/add/Main.ral.json
@@ -16,9 +16,6 @@
   "functions": [
     {
       "name": "main",
-      "usePreapprovedAssets": true,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/greeter/Greeter.ral.json
+++ b/artifacts/greeter/Greeter.ral.json
@@ -30,9 +30,6 @@
   "functions": [
     {
       "name": "greet",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/greeter/GreeterMain.ral.json
+++ b/artifacts/greeter/GreeterMain.ral.json
@@ -16,9 +16,6 @@
   "functions": [
     {
       "name": "main",
-      "usePreapprovedAssets": true,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/nft/DeprecatedNFTTest1.ral.json
+++ b/artifacts/nft/DeprecatedNFTTest1.ral.json
@@ -21,9 +21,6 @@
   "functions": [
     {
       "name": "getTokenUri",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/nft/DeprecatedNFTTest2.ral.json
+++ b/artifacts/nft/DeprecatedNFTTest2.ral.json
@@ -21,9 +21,6 @@
   "functions": [
     {
       "name": "getTokenUri",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],
@@ -33,9 +30,6 @@
     },
     {
       "name": "getCollectionId",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/nft/DeprecatedNFTTest3.ral.json
+++ b/artifacts/nft/DeprecatedNFTTest3.ral.json
@@ -21,9 +21,6 @@
   "functions": [
     {
       "name": "getTokenUri",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],
@@ -33,9 +30,6 @@
     },
     {
       "name": "returnNothing",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/nft/DeprecatedNFTTest4.ral.json
+++ b/artifacts/nft/DeprecatedNFTTest4.ral.json
@@ -21,9 +21,6 @@
   "functions": [
     {
       "name": "getTokenUri",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],
@@ -33,9 +30,6 @@
     },
     {
       "name": "getBool",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/nft/DeprecatedNFTTest5.ral.json
+++ b/artifacts/nft/DeprecatedNFTTest5.ral.json
@@ -21,9 +21,6 @@
   "functions": [
     {
       "name": "getTokenUri",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],
@@ -33,9 +30,6 @@
     },
     {
       "name": "returnMoreValues",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/nft/DeprecatedNFTTest6.ral.json
+++ b/artifacts/nft/DeprecatedNFTTest6.ral.json
@@ -21,9 +21,6 @@
   "functions": [
     {
       "name": "getTokenUri",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],
@@ -33,9 +30,6 @@
     },
     {
       "name": "getArray",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/nft/DeprecatedNFTTest7.ral.json
+++ b/artifacts/nft/DeprecatedNFTTest7.ral.json
@@ -21,9 +21,6 @@
   "functions": [
     {
       "name": "getTokenUri",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],
@@ -33,9 +30,6 @@
     },
     {
       "name": "returnNegativeIndex",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/nft/MintNFTTest.ral.json
+++ b/artifacts/nft/MintNFTTest.ral.json
@@ -22,9 +22,6 @@
   "functions": [
     {
       "name": "main",
-      "usePreapprovedAssets": true,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/nft/NFTCollectionTest.ral.json
+++ b/artifacts/nft/NFTCollectionTest.ral.json
@@ -27,9 +27,6 @@
   "functions": [
     {
       "name": "getCollectionUri",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],
@@ -39,9 +36,6 @@
     },
     {
       "name": "totalSupply",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],
@@ -51,9 +45,6 @@
     },
     {
       "name": "nftByIndex",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [
         "index"
       ],
@@ -69,9 +60,6 @@
     },
     {
       "name": "validateNFT",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [
         "nftId",
         "nftIndex"
@@ -88,9 +76,6 @@
     },
     {
       "name": "mint",
-      "usePreapprovedAssets": true,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [
         "nftUri"
       ],

--- a/artifacts/nft/NFTCollectionWithRoyaltyTest.ral.json
+++ b/artifacts/nft/NFTCollectionWithRoyaltyTest.ral.json
@@ -33,9 +33,6 @@
   "functions": [
     {
       "name": "getCollectionUri",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],
@@ -45,9 +42,6 @@
     },
     {
       "name": "totalSupply",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],
@@ -57,9 +51,6 @@
     },
     {
       "name": "nftByIndex",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [
         "index"
       ],
@@ -75,9 +66,6 @@
     },
     {
       "name": "validateNFT",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [
         "nftId",
         "nftIndex"
@@ -94,9 +82,6 @@
     },
     {
       "name": "royaltyAmount",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [
         "tokenId",
         "salePrice"
@@ -115,9 +100,6 @@
     },
     {
       "name": "payRoyalty",
-      "usePreapprovedAssets": true,
-      "useAssetsInContract": true,
-      "isPublic": true,
       "paramNames": [
         "payer",
         "amount"
@@ -134,9 +116,6 @@
     },
     {
       "name": "withdrawRoyalty",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": true,
-      "isPublic": true,
       "paramNames": [
         "recipient",
         "amount"
@@ -153,9 +132,6 @@
     },
     {
       "name": "mint",
-      "usePreapprovedAssets": true,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [
         "nftUri"
       ],

--- a/artifacts/nft/NFTTest.ral.json
+++ b/artifacts/nft/NFTTest.ral.json
@@ -27,9 +27,6 @@
   "functions": [
     {
       "name": "getTokenUri",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],
@@ -39,9 +36,6 @@
     },
     {
       "name": "getCollectionIndex",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/nft/WithdrawNFTCollectionTest.ral.json
+++ b/artifacts/nft/WithdrawNFTCollectionTest.ral.json
@@ -19,9 +19,6 @@
   "functions": [
     {
       "name": "main",
-      "usePreapprovedAssets": true,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/nft/WrongNFTTest.ral.json
+++ b/artifacts/nft/WrongNFTTest.ral.json
@@ -27,9 +27,6 @@
   "functions": [
     {
       "name": "getTokenUri",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],
@@ -39,9 +36,6 @@
     },
     {
       "name": "getCollectionIndex",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/sub/Sub.ral.json
+++ b/artifacts/sub/Sub.ral.json
@@ -30,9 +30,6 @@
   "functions": [
     {
       "name": "sub",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [
         "array"
       ],

--- a/artifacts/test/Assert.ral.json
+++ b/artifacts/test/Assert.ral.json
@@ -12,9 +12,6 @@
   "functions": [
     {
       "name": "test",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/test/Debug.ral.json
+++ b/artifacts/test/Debug.ral.json
@@ -12,9 +12,6 @@
   "functions": [
     {
       "name": "debug",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/test/InsertIntoMap.ral.json
+++ b/artifacts/test/InsertIntoMap.ral.json
@@ -22,9 +22,6 @@
   "functions": [
     {
       "name": "main",
-      "usePreapprovedAssets": true,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/test/MapTest.ral.json
+++ b/artifacts/test/MapTest.ral.json
@@ -12,9 +12,6 @@
   "functions": [
     {
       "name": "insert",
-      "usePreapprovedAssets": true,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [
         "key",
         "value"
@@ -31,9 +28,6 @@
     },
     {
       "name": "update",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [
         "key"
       ],
@@ -47,9 +41,6 @@
     },
     {
       "name": "remove",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [
         "key"
       ],

--- a/artifacts/test/MetaData.ral.json
+++ b/artifacts/test/MetaData.ral.json
@@ -12,9 +12,6 @@
   "functions": [
     {
       "name": "foo",
-      "usePreapprovedAssets": true,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],
@@ -22,9 +19,6 @@
     },
     {
       "name": "bar",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": true,
-      "isPublic": false,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],
@@ -32,9 +26,6 @@
     },
     {
       "name": "baz",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": false,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/test/OwnerOnly.ral.json
+++ b/artifacts/test/OwnerOnly.ral.json
@@ -18,9 +18,6 @@
   "functions": [
     {
       "name": "testOwner",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/test/RemoveFromMap.ral.json
+++ b/artifacts/test/RemoveFromMap.ral.json
@@ -19,9 +19,6 @@
   "functions": [
     {
       "name": "main",
-      "usePreapprovedAssets": true,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/test/TemplateArrayVar.ral.json
+++ b/artifacts/test/TemplateArrayVar.ral.json
@@ -25,9 +25,6 @@
   "functions": [
     {
       "name": "main",
-      "usePreapprovedAssets": true,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/test/TestAssert.ral.json
+++ b/artifacts/test/TestAssert.ral.json
@@ -16,9 +16,6 @@
   "functions": [
     {
       "name": "main",
-      "usePreapprovedAssets": true,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/test/UpdateMapValue.ral.json
+++ b/artifacts/test/UpdateMapValue.ral.json
@@ -19,9 +19,6 @@
   "functions": [
     {
       "name": "main",
-      "usePreapprovedAssets": true,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/test/UpdateUserAccount.ral.json
+++ b/artifacts/test/UpdateUserAccount.ral.json
@@ -22,9 +22,6 @@
   "functions": [
     {
       "name": "main",
-      "usePreapprovedAssets": true,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/test/UserAccount.ral.json
+++ b/artifacts/test/UserAccount.ral.json
@@ -27,9 +27,6 @@
   "functions": [
     {
       "name": "updateBalance",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [
         "tokens"
       ],
@@ -43,9 +40,6 @@
     },
     {
       "name": "updateAddress",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [
         "newAddress"
       ],
@@ -59,9 +53,6 @@
     },
     {
       "name": "getBalances",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/test/Warnings.ral.json
+++ b/artifacts/test/Warnings.ral.json
@@ -21,9 +21,6 @@
   "functions": [
     {
       "name": "foo",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [
         "x",
         "y"

--- a/artifacts/token/FakeTokenTest.ral.json
+++ b/artifacts/token/FakeTokenTest.ral.json
@@ -18,9 +18,6 @@
   "functions": [
     {
       "name": "getSymbol",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],
@@ -30,9 +27,6 @@
     },
     {
       "name": "getName",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],
@@ -42,9 +36,6 @@
     },
     {
       "name": "getDecimals",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],
@@ -54,9 +45,6 @@
     },
     {
       "name": "getTotalSupply",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],
@@ -66,9 +54,6 @@
     },
     {
       "name": "foo",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/token/TokenTest.ral.json
+++ b/artifacts/token/TokenTest.ral.json
@@ -30,9 +30,6 @@
   "functions": [
     {
       "name": "getSymbol",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],
@@ -42,9 +39,6 @@
     },
     {
       "name": "getName",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],
@@ -54,9 +48,6 @@
     },
     {
       "name": "getDecimals",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],
@@ -66,9 +57,6 @@
     },
     {
       "name": "getTotalSupply",
-      "usePreapprovedAssets": false,
-      "useAssetsInContract": false,
-      "isPublic": true,
       "paramNames": [],
       "paramTypes": [],
       "paramIsMutable": [],

--- a/artifacts/ts/MapTest.ts
+++ b/artifacts/ts/MapTest.ts
@@ -119,8 +119,16 @@ export class MapTestInstance extends ContractInstance {
   }
 
   maps = {
-    map0: new RalphMap<Address, MapValue>(MapTest.contract, this, "map0"),
-    map1: new RalphMap<bigint, bigint>(MapTest.contract, this, "map1"),
+    map0: new RalphMap<Address, MapValue>(
+      MapTest.contract,
+      this.contractId,
+      "map0"
+    ),
+    map1: new RalphMap<bigint, bigint>(
+      MapTest.contract,
+      this.contractId,
+      "map1"
+    ),
   };
 
   async fetchState(): Promise<MapTestTypes.State> {

--- a/packages/cli/cli_internal.ts
+++ b/packages/cli/cli_internal.ts
@@ -23,7 +23,15 @@ import path from 'path'
 import { deployAndSaveProgress } from './scripts/deploy'
 import { Configuration, DEFAULT_CONFIGURATION_VALUES } from './src/types'
 import { createProject } from './scripts/create-project'
-import { checkFullNodeVersion, codegen, getConfigFile, getSdkFullNodeVersion, isNetworkLive, loadConfig } from './src'
+import {
+  checkFullNodeVersion,
+  codegen,
+  getConfigFile,
+  getSdkFullNodeVersion,
+  isDeployedOnMainnet,
+  isNetworkLive,
+  loadConfig
+} from './src'
 
 function getConfig(options: any): Configuration {
   const configFile = options.config ? (options.config as string) : getConfigFile()
@@ -94,7 +102,15 @@ program
       console.log(`Full node version: ${connectedFullNodeVersion}`)
 
       const cwd = path.resolve(process.cwd())
-      await Project.build(config.compilerOptions, cwd, config.sourceDir, config.artifactDir, connectedFullNodeVersion)
+      const skipSaveArtifacts = config.skipSaveArtifacts || isDeployedOnMainnet(config)
+      await Project.build(
+        config.compilerOptions,
+        cwd,
+        config.sourceDir,
+        config.artifactDir,
+        connectedFullNodeVersion,
+        skipSaveArtifacts
+      )
       console.log('✅ Compilation completed!')
       if (options.skipGenerate) {
         return

--- a/packages/cli/src/codegen.ts
+++ b/packages/cli/src/codegen.ts
@@ -152,7 +152,9 @@ function genMaps(contract: Contract): string {
   const maps = mapsSig.names.map((name, index) => {
     const mapType = mapsSig.types[`${index}`]
     const [key, value] = parseMapType(mapType)
-    return `${name}: new RalphMap<${toTsType(key)}, ${toTsType(value)}>(${contract.name}.contract, this, '${name}')`
+    return `${name}: new RalphMap<${toTsType(key)}, ${toTsType(value)}>(${
+      contract.name
+    }.contract, this.contractId, '${name}')`
   })
   return `maps = { ${maps.join(',')} }`
 }

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -60,6 +60,7 @@ export interface Configuration<Settings = unknown> {
   networks: Record<NetworkId, Network<Settings>>
 
   enableDebugMode?: boolean
+  skipSaveArtifacts?: boolean
 }
 
 export const DEFAULT_CONFIGURATION_VALUES = {
@@ -85,7 +86,8 @@ export const DEFAULT_CONFIGURATION_VALUES = {
       networkId: 0,
       confirmations: 2
     }
-  }
+  },
+  skipSaveArtifacts: false
 }
 
 export interface Environment<Settings = unknown> {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -107,6 +107,11 @@ export function getDeploymentFilePath(configuration: Configuration, networkId: N
     : path.join(configuration.artifactDir ?? DEFAULT_CONFIGURATION_VALUES.artifactDir, `.deployments.${networkId}.json`)
 }
 
+export function isDeployedOnMainnet(configuration: Configuration): boolean {
+  const file = getDeploymentFilePath(configuration, 'mainnet')
+  return fs.existsSync(file)
+}
+
 export function getNetwork<Settings = unknown>(
   configuration: Configuration<Settings>,
   networkId: NetworkId

--- a/packages/web3/src/codec/contract-codec.test.ts
+++ b/packages/web3/src/codec/contract-codec.test.ts
@@ -17,7 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { Buffer } from 'buffer/'
-import { Contract, Project, web3, Struct, decodeArrayType } from '@alephium/web3'
+import { Contract, Project, web3, decodeArrayType } from '@alephium/web3'
 import { Method } from './method-codec'
 import { contractCodec, toHalfDecoded } from './contract-codec'
 import {
@@ -96,7 +96,9 @@ describe('Encode & decode contract', function () {
       [
         {
           isPublic: true,
-          assetModifier: 0,
+          usePreapprovedAssets: false,
+          useContractAssets: false,
+          usePayToContractOnly: false,
           argsLength: 0,
           localsLength: 0,
           returnLength: 1,
@@ -104,7 +106,9 @@ describe('Encode & decode contract', function () {
         },
         {
           isPublic: true,
-          assetModifier: 0,
+          usePreapprovedAssets: false,
+          useContractAssets: false,
+          usePayToContractOnly: false,
           argsLength: 0,
           localsLength: 0,
           returnLength: 1,
@@ -112,7 +116,9 @@ describe('Encode & decode contract', function () {
         },
         {
           isPublic: false,
-          assetModifier: 0,
+          usePreapprovedAssets: false,
+          useContractAssets: false,
+          usePayToContractOnly: false,
           argsLength: 0,
           localsLength: 0,
           returnLength: 1,
@@ -120,7 +126,9 @@ describe('Encode & decode contract', function () {
         },
         {
           isPublic: true,
-          assetModifier: 0,
+          usePreapprovedAssets: false,
+          useContractAssets: false,
+          usePayToContractOnly: false,
           argsLength: 0,
           localsLength: 0,
           returnLength: 1,
@@ -205,7 +213,9 @@ describe('Encode & decode contract', function () {
       [
         {
           isPublic: false,
-          assetModifier: 0,
+          usePreapprovedAssets: false,
+          useContractAssets: false,
+          usePayToContractOnly: false,
           argsLength: 2,
           localsLength: 4,
           returnLength: 2,
@@ -230,7 +240,9 @@ describe('Encode & decode contract', function () {
         },
         {
           isPublic: true,
-          assetModifier: 3,
+          usePreapprovedAssets: true,
+          useContractAssets: false,
+          usePayToContractOnly: false,
           argsLength: 4,
           localsLength: 9,
           returnLength: 0,
@@ -327,7 +339,9 @@ describe('Encode & decode contract', function () {
     expect(toHalfDecoded(decodedContract)).toEqual(decoded)
     decodedContract.methods.map((decodedMethod, index) => {
       expect(decodedMethod.isPublic).toEqual(methods[index].isPublic)
-      expect(decodedMethod.assetModifier).toEqual(methods[index].assetModifier)
+      expect(decodedMethod.usePreapprovedAssets).toEqual(methods[index].usePreapprovedAssets)
+      expect(decodedMethod.useContractAssets).toEqual(methods[index].useContractAssets)
+      expect(decodedMethod.usePayToContractOnly).toEqual(methods[index].usePayToContractOnly)
       expect(decodedMethod.argsLength).toEqual(methods[index].argsLength)
       expect(decodedMethod.localsLength).toEqual(methods[index].localsLength)
       expect(decodedMethod.returnLength).toEqual(methods[index].returnLength)
@@ -362,27 +376,15 @@ describe('Encode & decode contract', function () {
 
     expect(decodedContract.fieldLength).toEqual(getTypesLength(contract.fieldsSig.types))
     decodedContract.methods.map((decodedMethod, index) => {
-      const contractFunction = contract.functions[index]
-      expect(decodedMethod.isPublic).toEqual(contractFunction.isPublic)
-      expect(decodedMethod.assetModifier).toEqual(
-        assetModifier(contractFunction.usePreapprovedAssets, contractFunction.useAssetsInContract)
-      )
-      expect(decodedMethod.argsLength).toEqual(getTypesLength(contractFunction.paramTypes))
-      expect(decodedMethod.returnLength).toEqual(getTypesLength(contractFunction.returnTypes))
+      const decoded = contract.decodedMethods[index]
+      const functionSig = contract.functions[index]
+      expect(decodedMethod.isPublic).toEqual(decoded.isPublic)
+      expect(decodedMethod.usePreapprovedAssets).toEqual(decoded.usePreapprovedAssets)
+      expect(decodedMethod.useContractAssets).toEqual(decoded.useContractAssets)
+      expect(decodedMethod.argsLength).toEqual(getTypesLength(functionSig.paramTypes))
+      expect(decodedMethod.returnLength).toEqual(getTypesLength(functionSig.returnTypes))
     })
 
     expect(contract.bytecode).toEqual(encoded.toString('hex'))
-  }
-
-  function assetModifier(usePreapprovedAssets: boolean, useAssetsInContract: boolean): number {
-    if (!usePreapprovedAssets && !useAssetsInContract) {
-      return 0
-    } else if (usePreapprovedAssets && useAssetsInContract) {
-      return 1
-    } else if (!usePreapprovedAssets && useAssetsInContract) {
-      return 2
-    } else {
-      return 3
-    }
   }
 })

--- a/packages/web3/std/fungible_token_interface.ral
+++ b/packages/web3/std/fungible_token_interface.ral
@@ -1,4 +1,5 @@
 @std(id = #0001)
+@using(methodSelector = false)
 Interface IFungibleToken {
   pub fn getSymbol() -> ByteVec
 

--- a/packages/web3/std/nft_collection_interface.ral
+++ b/packages/web3/std/nft_collection_interface.ral
@@ -1,6 +1,7 @@
 import "std/nft_interface"
 
 @std(id = #0002)
+@using(methodSelector = false)
 Interface INFTCollection {
    // Collection Uri points to a json file containing metadata for the NFT collection.
    //

--- a/packages/web3/std/nft_collection_with_royalty_interface.ral
+++ b/packages/web3/std/nft_collection_with_royalty_interface.ral
@@ -1,6 +1,7 @@
 import "std/nft_collection_interface"
 
 @std(id = #000201)
+@using(methodSelector = false)
 Interface INFTCollectionWithRoyalty extends INFTCollection {
     pub fn royaltyAmount(tokenId: ByteVec, salePrice: U256) -> (U256)
 

--- a/packages/web3/std/nft_interface.ral
+++ b/packages/web3/std/nft_interface.ral
@@ -1,4 +1,5 @@
 @std(id = #0003)
+@using(methodSelector = false)
 Interface INFT {
    // Token Uri points to a json file containing metadata for the NFT.
    //

--- a/test/contract.test.ts
+++ b/test/contract.test.ts
@@ -271,9 +271,9 @@ describe('contract', function () {
     await Project.build({ errorOnWarnings: false })
 
     expect(MetaData.contract.functions.map((func) => func.name)).toEqual(['foo', 'bar', 'baz'])
-    expect(MetaData.contract.publicFunctions()).toEqual(['foo'])
-    expect(MetaData.contract.usingPreapprovedAssetsFunctions()).toEqual(['foo'])
-    expect(MetaData.contract.usingAssetsInContractFunctions()).toEqual(['bar'])
+    expect(MetaData.contract.publicFunctions().map((f) => f.name)).toEqual(['foo'])
+    expect(MetaData.contract.usingPreapprovedAssetsFunctions().map((f) => f.name)).toEqual(['foo'])
+    expect(MetaData.contract.usingAssetsInContractFunctions().map((f) => f.name)).toEqual(['bar'])
   })
 
   it('should handle compiler warnings', async () => {


### PR DESCRIPTION
1. Remove unnecessary fields from the artifact
2. Add the `@using(methodSelector = false)` annotation to existing std interfaces
3. Add a `skipSaveArtifacts` flag in the CLI:
    1. If `skipSaveArtifacts` is enabled or the contracts have been deployed on the mainnet, we won't regenerate bytecode for those unchanged contract
    2. If the existing contract code is changed, we will regenerate bytecode for the contract
    3. If the existing contract code remains unchanged but new contracts are added, we will only regenerate bytecode for the new contracts