### PR TITLE
Fix exports in web3

### DIFF
--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -7,8 +7,14 @@
   "browser": "dist/alephium-web3.min.js",
   "types": "dist/src/index.d.ts",
   "exports": {
-    "node": "./dist/src/index.js",
-    "default": "./dist/alephium-web3.min.js"
+    "node": {
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
+    },
+    "default": {
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/alephium-web3.min.js"
+    }
   },
   "typesVersions": {
     "*": {


### PR DESCRIPTION
A discord user reported this error with the latest sdk version:

```
Could not find a declaration file for module '@alephium/web3'. '/node_modules/@alephium/web3/dist/alephium-web3.min.js' implicitly has an 'any' type.
  There are types at '/node_modules/@alephium/web3/dist/src/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@alephium/web3' library may need to update its package.json or typings
```

This error will only appear in typescript 5.x version and when `"moduleResolution": "bundler"` is used. Here is a repro example: https://github.com/not-reed/alephium-types-repro

I tested the repro example, dex, bridge, nextjs-template, desktop wallet, and explorer using the code form this PR. It seems to work as expected.

@nop33 Could you please double-check the wallet and explorer when you have time? Thanks a lot!