### PR TITLE
Fix web3-wallet entry points

### DIFF
--- a/packages/web3-wallet/package.json
+++ b/packages/web3-wallet/package.json
@@ -30,7 +30,7 @@
   },
   "author": "Alephium dev <dev@alephium.org>",
   "scripts": {
-    "build": "rm -rf dist/* && npx tsc --build .",
+    "build": "rm -rf dist/* && npx tsc --build . && webpack",
     "test": "jest -i --config ./jest-config.json"
   },
   "type": "commonjs",
@@ -51,7 +51,9 @@
     "@types/rewire": "^2.5.28",
     "@typescript-eslint/eslint-plugin": "^5.57.0",
     "@typescript-eslint/parser": "^5.57.0",
-    "crypto-browserify": "^3.12.0"
+    "crypto-browserify": "^3.12.0",
+    "webpack": "^5.77.0",
+    "webpack-cli": "^4.10.0"
   },
   "engines": {
     "node": ">=14.0.0",

--- a/packages/web3-wallet/package.json
+++ b/packages/web3-wallet/package.json
@@ -8,10 +8,17 @@
   ],
   "license": "GPL",
   "main": "dist/src/index.js",
-  "browser": "dist/alephium-web3.min.js",
+  "browser": "dist/alephium-web3-wallet.min.js",
   "types": "dist/src/index.d.ts",
   "exports": {
-    ".": "./dist/src/index.js"
+    "node": {
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
+    },
+    "default": {
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/alephium-web3-wallet.min.js"
+    }
   },
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -631,6 +631,12 @@ importers:
       crypto-browserify:
         specifier: ^3.12.0
         version: 3.12.0
+      webpack:
+        specifier: ^5.77.0
+        version: 5.77.0(@swc/core@1.5.28)(webpack-cli@4.10.0)
+      webpack-cli:
+        specifier: ^4.10.0
+        version: 4.10.0(webpack@5.77.0)
 
 packages:
 


### PR DESCRIPTION
So there are 2 problems with `@alephium/web3-wallet`.

The first one is that the [name of the Webpack minified output](https://github.com/alephium/alephium-web3/blob/v0.45.0/packages/web3-wallet/webpack.config.js#L44) is `alephium-web3-wallet.min.js`, but in the `package.json` it is [referred wrongly](https://github.com/alephium/alephium-web3/blob/v0.45.0/packages/web3-wallet/package.json#L11) as `alephium-web3.min.js`.

The second is that Webpack was not being executed so the minified file that RN expected was never there.

This PR should be addressing both issues.

Potentially closes https://github.com/alephium/alephium-web3/issues/362