### PR TITLE
Add a silent flag to remove deployment log output

### DIFF
--- a/.project.json
+++ b/.project.json
@@ -186,7 +186,7 @@
     },
     "INFT": {
       "sourceFile": "../packages/web3/std/nft_interface.ral",
-      "sourceCodeHash": "acff0211f936d18d3f4a01ddd8f4fe8fbdf0dba9e8b9204b233a48cba1c80d8b",
+      "sourceCodeHash": "92956f4e61c198f011b48dbda2ed76193ffc79ac9c39f60bf1763a34e02f2c41",
       "bytecodeDebugPatch": "",
       "codeHashDebug": "",
       "warnings": []

--- a/packages/cli/cli_internal.ts
+++ b/packages/cli/cli_internal.ts
@@ -189,13 +189,17 @@ program
     'run scripts to a specific index(inclusive), the number refers to the prefix of the script file'
   )
   .option('--debug', 'show detailed debug information such as error stack traces')
+  .option('--silent', 'remove deployment log output')
   .action(async (options) => {
     try {
       const config = getConfig(options)
       const networkId = checkAndGetNetworkId(options.network)
       const fromIndex = tryGetScriptIndex(options.from)
       const toIndex = tryGetScriptIndex(options.to)
-      await deployAndSaveProgress(config, networkId, fromIndex, toIndex)
+      if (config.enableDebugMode && options.silent) {
+        throw new Error('The `--silent` and `--debug` options cannot be enabled at the same time')
+      }
+      await deployAndSaveProgress(config, networkId, options.silent, fromIndex, toIndex)
     } catch (error) {
       program.error(`✘ Failed to deploy contracts, error: ${buildErrorOutput(error, isDebugModeEnabled())}`)
     }

--- a/packages/cli/cli_internal.ts
+++ b/packages/cli/cli_internal.ts
@@ -38,8 +38,9 @@ function getConfig(options: any): Configuration {
   const configFile = options.config ? (options.config as string) : getConfigFile()
   console.log(`Loading alephium config file: ${configFile}`)
   const config = loadConfig(configFile)
-  if (config.enableDebugMode || options.debug) enableDebugMode()
-  return config
+  const isDebugModeEnabled = config.enableDebugMode || options.debug
+  if (isDebugModeEnabled) enableDebugMode()
+  return { ...config, enableDebugMode: isDebugModeEnabled }
 }
 
 function checkAndGetNetworkId(networkId?: string): NetworkId {

--- a/packages/cli/scripts/deploy.ts
+++ b/packages/cli/scripts/deploy.ts
@@ -24,6 +24,7 @@ import { NetworkId } from '@alephium/web3'
 export async function deployAndSaveProgress<Settings = unknown>(
   configuration: Configuration<Settings>,
   networkId: NetworkId,
+  silent: boolean,
   fromIndex?: number,
   toIndex?: number
 ): Promise<void> {
@@ -31,7 +32,7 @@ export async function deployAndSaveProgress<Settings = unknown>(
   const deployments = await Deployments.from(deploymentsFile)
   let scriptExecuted: boolean
   try {
-    scriptExecuted = await deploy(configuration, networkId, deployments, fromIndex, toIndex)
+    scriptExecuted = await deploy(configuration, networkId, deployments, fromIndex, toIndex, silent)
   } catch (error) {
     await deployments.saveToFile(deploymentsFile, configuration, false)
     console.error(`Failed to deploy the project`)
@@ -39,5 +40,5 @@ export async function deployAndSaveProgress<Settings = unknown>(
   }
 
   await deployments.saveToFile(deploymentsFile, configuration, true)
-  if (scriptExecuted) console.log('✅ Scripts deployment executed!')
+  if (scriptExecuted && !silent) console.log('✅ Scripts deployment executed!')
 }

--- a/packages/cli/src/deployment.ts
+++ b/packages/cli/src/deployment.ts
@@ -323,9 +323,9 @@ function getTaskId(code: Contract | Script, taskTag?: string): string {
   return `${code.name}:${taskTag}`
 }
 
-function getDebugLogger(enableDebugMode: boolean): (string) => void {
+function getDebugLogger(debugModeEnabled: boolean): (string) => void {
   return (message: string): void => {
-    if (enableDebugMode) {
+    if (debugModeEnabled) {
       console.log(message)
     }
   }


### PR DESCRIPTION
By default, the `CLI` will output the deployment log. Users can use the `--silent` flag to remove the deployment log output, which is similar to Hardhat.