### PR TITLE
Fix loading compiler options

### DIFF
--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -252,7 +252,10 @@ export class ProjectArtifact {
       const content = await fsPromises.readFile(filepath)
       const json = JSON.parse(content.toString())
       const fullNodeVersion = json.fullNodeVersion as string
-      const compilerOptionsUsed = json.compilerOptionsUsed as node.CompilerOptions
+      const compilerOptionsUsed = { ...DEFAULT_NODE_COMPILER_OPTIONS }
+      Object.entries(json.compilerOptionsUsed).forEach(([key, value]) => {
+        compilerOptionsUsed[`${key}`] = value
+      })
       const files = new Map(Object.entries<CodeInfo>(json.infos))
       return new ProjectArtifact(fullNodeVersion, compilerOptionsUsed, files)
     } catch (error) {


### PR DESCRIPTION
Because we've introduced a new compiler option, an error will be thrown when loading incomplete compiler options. This will cause the project before the Rhone upgrade to be recompiled. This PR resolves this issue.