### PR TITLE
Replace WalletConnect relay URL from .com to .org

### DIFF
--- a/packages/walletconnect/src/constants.ts
+++ b/packages/walletconnect/src/constants.ts
@@ -33,6 +33,6 @@ export const RELAY_METHODS = [
 
 export const LOGGER = 'error'
 
-export const RELAY_URL = 'wss://relay.walletconnect.com'
+export const RELAY_URL = 'wss://relay.walletconnect.org'
 
 export const ALEPHIUM_DEEP_LINK = 'alephium://'


### PR DESCRIPTION
Related:
- https://github.com/WalletConnect/walletconnect-monorepo/pull/5151
- https://docs.walletconnect.com/advanced/faq#the-default-relay-endpoint-is-blocked-how-can-i-get-around-this