### PR TITLE
typo fix: on type defs

### DIFF
--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -111,13 +111,13 @@ export interface Deployer {
   account: Account
 
   deployContract<T extends ContractInstance, P extends Fields>(
-    constractFactory: ContractFactory<T, P>,
+    contractFactory: ContractFactory<T, P>,
     params: DeployContractParams<P>,
     taskTag?: string
   ): Promise<DeployContractResult<T>>
 
   deployContractTemplate<T extends ContractInstance, P extends Fields>(
-    constractFactory: ContractFactory<T, P>,
+    contractFactory: ContractFactory<T, P>,
     taskTag?: string
   ): Promise<DeployContractResult<T>>
 


### PR DESCRIPTION
## Typo Fix
1. Found a small type definition typo of `constractFactory` while writing some contracts in my IDE.
2. checked the other type names in the file, made sure the correct name should be `contractFactory`
3. Made the change