### PR TITLE
Add browser entry in WC provider package.json

### DIFF
--- a/packages/walletconnect/package.json
+++ b/packages/walletconnect/package.json
@@ -10,6 +10,7 @@
   },
   "license": "Apache-2.0",
   "main": "dist/cjs/index.js",
+  "browser": "dist/umd/index.min.js",
   "types": "dist/cjs/index.d.ts",
   "unpkg": "dist/umd/index.min.js",
   "files": [


### PR DESCRIPTION
Similarly to how the `@alephium/web3` package provides a [`"browser"` entry in its package.json](https://github.com/alephium/alephium-web3/blob/master/packages/web3/package.json#L7), so must the `@alephium/walletconnect-provider`. It helps frontend projects chose the right build file for their environment.