### PR TITLE
Support custom connectors in web3-react

### DIFF
--- a/packages/walletconnect/src/types.ts
+++ b/packages/walletconnect/src/types.ts
@@ -108,3 +108,4 @@ export interface ChainInfo {
 }
 
 export type ProjectMetaData = SignClientTypes.Metadata
+export type SignClientOptions = SignClientTypes.Options

--- a/packages/web3-react/src/components/ConnectModal/ConnectWithInjector/index.tsx
+++ b/packages/web3-react/src/components/ConnectModal/ConnectWithInjector/index.tsx
@@ -45,6 +45,8 @@ import { useConnect } from '../../../hooks/useConnect'
 import { AlephiumWindowObject } from '@alephium/get-extension-wallet'
 import { ConnectorButton, ConnectorIcon, ConnectorLabel, ConnectorsContainer } from '../../Pages/Connectors/styles'
 import { useInjectedProviders } from '../../../hooks/useInjectedProviders'
+import { getInjectedProviderId } from '../../../utils/injectedProviders'
+import { InjectedProviderId } from '../../../types'
 
 const states = {
   CONNECTED: 'connected',
@@ -93,8 +95,8 @@ const ConnectWithInjector: React.FC<{
 }> = ({ connectorId, switchConnectMethod, forceState }) => {
   const { setOpen } = useConnectSettingContext()
   const providers = useInjectedProviders()
-  const [injectedProvider, setInjectedProvider] = useState<AlephiumWindowObject | undefined>(
-    providers.length !== 0 ? providers[0] : undefined
+  const [injectedProviderId, setInjectedProviderId] = useState<InjectedProviderId | undefined>(
+    providers.length !== 0 ? getInjectedProviderId(providers[0]) : undefined
   )
   console.log(`providers size: ${providers.length}`)
   const { connect } = useConnect()
@@ -127,23 +129,23 @@ const ConnectWithInjector: React.FC<{
   )
 
   const handleConnect = useCallback(
-    (injectedProvider) => {
-      setInjectedProvider(injectedProvider)
+    (injectedProviderId) => {
+      setInjectedProviderId(injectedProviderId)
       setStatus(states.CONNECTING)
     },
-    [setStatus, setInjectedProvider]
+    [setStatus, setInjectedProviderId]
   )
 
   const runConnect = useCallback(() => {
     if (!hasExtensionInstalled || status === states.LISTING) return
 
-    connect(injectedProvider).then((address) => {
+    connect(injectedProviderId).then((address) => {
       if (!!address) {
         setStatus(states.CONNECTED)
       }
       setOpen(false)
     })
-  }, [hasExtensionInstalled, setOpen, connect, status, injectedProvider])
+  }, [hasExtensionInstalled, setOpen, connect, status, injectedProviderId])
 
   const connectTimeoutRef = useRef<ReturnType<typeof setTimeout>>()
   useEffect(() => {
@@ -210,13 +212,13 @@ const ConnectWithInjector: React.FC<{
           <>
             <ConnectorsContainer>
               {providers.map((provider) => {
-                const name = getProviderName(provider)
+                const id = getInjectedProviderId(provider)
                 return (
-                  <ConnectorButton key={name} onClick={() => handleConnect(provider)}>
+                  <ConnectorButton key={id} onClick={() => handleConnect(id)}>
                     <ConnectorIcon>
                       <img src={provider.icon} alt="Icon" />
                     </ConnectorIcon>
-                    <ConnectorLabel>{name}</ConnectorLabel>
+                    <ConnectorLabel>{id}</ConnectorLabel>
                   </ConnectorButton>
                 )
               })}
@@ -497,10 +499,3 @@ const ConnectWithInjector: React.FC<{
 }
 
 export default ConnectWithInjector
-
-function getProviderName(provider: AlephiumWindowObject): string {
-  if (provider.icon.includes('onekey')) {
-    return 'OneKey'
-  }
-  return 'Alephium'
-}

--- a/packages/web3-react/src/contexts/alephiumConnect.tsx
+++ b/packages/web3-react/src/contexts/alephiumConnect.tsx
@@ -20,6 +20,7 @@ import React, { createContext, useContext } from 'react'
 import { Account, KeyType, SignerProvider, NetworkId } from '@alephium/web3'
 import { Theme, Mode, CustomTheme, ConnectorId } from '../types'
 import { node } from '@alephium/web3'
+import { Connectors } from '../utils/connector'
 
 type Error = string | React.ReactNode | null
 
@@ -64,6 +65,7 @@ export type AlephiumConnectContextValue = {
   setConnectionStatus: (status: ConnectionStatus) => void
   signerProvider?: SignerProvider
   setSignerProvider: (signerProvider: SignerProvider | undefined) => void
+  connectors: Connectors
 }
 
 export const AlephiumConnectContext = createContext<AlephiumConnectContextValue | null>(null)

--- a/packages/web3-react/src/hooks/useConnect.tsx
+++ b/packages/web3-react/src/hooks/useConnect.tsx
@@ -18,12 +18,21 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import { useAlephiumConnectContext, useConnectSettingContext } from '../contexts/alephiumConnect'
 import { useCallback, useMemo } from 'react'
 import { removeLastConnectedAccount } from '../utils/storage'
-import { ConnectResult, getConnectorById } from '../utils/connector'
+import { ConnectResult } from '../utils/connector'
+import { InjectedProviderId } from '../types'
 
 export function useConnect() {
   const { connectorId } = useConnectSettingContext()
-  const { signerProvider, setSignerProvider, setConnectionStatus, setAccount, addressGroup, network, keyType } =
-    useAlephiumConnectContext()
+  const {
+    signerProvider,
+    setSignerProvider,
+    setConnectionStatus,
+    setAccount,
+    addressGroup,
+    network,
+    keyType,
+    connectors
+  } = useAlephiumConnectContext()
 
   const onDisconnected = useCallback(() => {
     removeLastConnectedAccount()
@@ -50,13 +59,13 @@ export function useConnect() {
   }, [onDisconnected, onConnected, network, addressGroup, keyType])
 
   const connector = useMemo(() => {
-    return getConnectorById(connectorId)
-  }, [connectorId])
+    return connectors[`${connectorId}`]
+  }, [connectorId, connectors])
 
   const connect = useMemo(() => {
-    return async (injectedProvider?) => {
+    return async (injectedProviderId?: InjectedProviderId) => {
       setConnectionStatus('connecting')
-      return await connector.connect({ ...connectOptions, injectedProvider })
+      return await connector.connect({ ...connectOptions, injectedProviderId })
     }
   }, [connector, connectOptions, setConnectionStatus])
 

--- a/packages/web3-react/src/hooks/useInjectedProviders.tsx
+++ b/packages/web3-react/src/hooks/useInjectedProviders.tsx
@@ -17,7 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { useSyncExternalStore } from 'use-sync-external-store/shim'
-import { injectedProviderStore } from '../utils/providers'
+import { injectedProviderStore } from '../utils/injectedProviders'
 
 export const useInjectedProviders = () =>
   useSyncExternalStore(

--- a/packages/web3-react/src/index.ts
+++ b/packages/web3-react/src/index.ts
@@ -31,3 +31,4 @@ export { useBalance } from './hooks/useBalance'
 export { useWallet, Wallet, useWalletConfig, WalletConfig } from './hooks/useWallet'
 
 export * from './contexts/alephiumConnect'
+export * from './utils/connector'

--- a/packages/web3-react/src/types.ts
+++ b/packages/web3-react/src/types.ts
@@ -33,6 +33,7 @@ export type Mode = 'light' | 'dark' | 'auto'
 export type CustomTheme = any // TODO: define type
 export const connectorIds = ['injected', 'walletConnect', 'desktopWallet'] as const
 export type ConnectorId = (typeof connectorIds)[number]
+export type InjectedProviderId = 'Alephium' | 'OneKey'
 
 export type CustomStyle = {
   theme?: Theme

--- a/packages/web3-react/src/utils/injectedProviders.ts
+++ b/packages/web3-react/src/utils/injectedProviders.ts
@@ -19,10 +19,12 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import {
   alephiumProvider,
   AlephiumWindowObject,
+  getDefaultAlephiumWallet,
   getWalletObject,
   isWalletObj,
   providerInitializedEvent
 } from '@alephium/get-extension-wallet'
+import { InjectedProviderId } from '../types'
 
 export type InjectedProviderListener = (providers: AlephiumWindowObject[]) => void
 
@@ -99,3 +101,18 @@ function createProviderStore() {
 }
 
 export const injectedProviderStore = createProviderStore()
+
+export function getInjectedProviderId(provider: AlephiumWindowObject): InjectedProviderId {
+  if (provider.icon.includes('onekey')) {
+    return 'OneKey'
+  }
+  return 'Alephium'
+}
+
+export async function getInjectedProvider(
+  providers: AlephiumWindowObject[],
+  id?: InjectedProviderId
+): Promise<AlephiumWindowObject | undefined> {
+  if (id === undefined) return getDefaultAlephiumWallet()
+  return providers.find((p) => getInjectedProviderId(p) === id)
+}


### PR DESCRIPTION
To address [this WalletConnect issue](https://github.com/WalletConnect/walletconnect-monorepo/issues/5542) in bridge ui, we need to support passing more `SignClient` options in web3-react. This PR follows a similar approach to `wagmi` and `connectkit` by introducing a `connectors` parameter. In most cases, dApp developers do not need to specify this parameter.