### PR TITLE
Add getAllContracts method

### DIFF
--- a/artifacts/ts/contracts.ts
+++ b/artifacts/ts/contracts.ts
@@ -6,6 +6,10 @@ import { Contract, ContractFactory } from "@alephium/web3";
 
 let contracts: ContractFactory<any>[] | undefined = undefined;
 
+export function getAllContracts(): ContractFactory<any>[] {
+  return contracts ?? [];
+}
+
 export function registerContract(factory: ContractFactory<any>) {
   if (contracts === undefined) {
     contracts = [factory];

--- a/artifacts/ts/index.ts
+++ b/artifacts/ts/index.ts
@@ -31,4 +31,5 @@ export * from "./Transact";
 export * from "./UserAccount";
 export * from "./Warnings";
 export * from "./WrongNFTTest";
+export * from "./contracts";
 export * from "./scripts";

--- a/packages/cli/src/codegen.ts
+++ b/packages/cli/src/codegen.ts
@@ -635,7 +635,7 @@ function genIndexTs(outDir: string, exports: string[]) {
   formatAndSaveToFile(indexPath, header + exportStatements)
 }
 
-function genContractByCodeHash(outDir: string) {
+function genContractByCodeHash(outDir: string, exports: string[]) {
   const source = `
     ${header}
 
@@ -663,6 +663,7 @@ function genContractByCodeHash(outDir: string) {
     }
   `
   const filename = 'contracts.ts'
+  exports.push('./contracts')
   const sourcePath = path.join(outDir, filename)
   formatAndSaveToFile(sourcePath, source)
 }
@@ -918,7 +919,7 @@ export function codegen(project: Project) {
     genStructTypes(outDir)
     genGlobalConstants(project, outDir)
     genContracts(outDir, artifactDir, exports)
-    genContractByCodeHash(outDir)
+    genContractByCodeHash(outDir, exports)
     genScripts(outDir, artifactDir, exports)
     genIndexTs(outDir, exports)
   } catch (error) {

--- a/packages/cli/src/codegen.ts
+++ b/packages/cli/src/codegen.ts
@@ -643,6 +643,10 @@ function genContractByCodeHash(outDir: string) {
 
     let contracts: ContractFactory<any>[] | undefined = undefined
 
+    export function getAllContracts(): ContractFactory<any>[] {
+      return contracts ?? []
+    }
+
     export function registerContract(factory: ContractFactory<any>) {
       if (contracts === undefined) {
         contracts = [factory]


### PR DESCRIPTION
This function is used to get the contract list from a third-party project and add it to the current project's contract list, which helps prevent the `Unknown code with code hash` error.