### PR TITLE
Fix getChangedSources

### DIFF
--- a/packages/cli/cli_internal.ts
+++ b/packages/cli/cli_internal.ts
@@ -31,11 +31,12 @@ function getConfig(options: any): Configuration {
   const configFile = options.config ? (options.config as string) : getConfigFile()
   console.log(`Loading alephium config file: ${configFile}`)
   const config = loadConfig(configFile)
-  if (config.forceRecompile && config.skipRecompileIfDeployedOnMainnet) {
+  const forceRecompile = options.force || config.forceRecompile
+  if (forceRecompile && config.skipRecompileIfDeployedOnMainnet) {
     throw new Error(`The forceRecompile and skipRecompileIfDeployedOnMainnet flags cannot be enabled at the same time`)
   }
 
-  if (config.forceRecompile && (config.skipRecompileContracts ?? []).length > 0) {
+  if (forceRecompile && (config.skipRecompileContracts ?? []).length > 0) {
     throw new Error(`The skipRecompileContracts cannot be specified when forceRecompile is enabled`)
   }
 
@@ -96,6 +97,7 @@ program
   .option('-n, --network <network-type>', 'network type')
   .option('--skipGenerate', 'skip generate typescript code by contract artifacts')
   .option('--debug', 'show detailed debug information such as error stack traces')
+  .option('--force', 'enable force recompile')
   .action(async (options) => {
     try {
       const config = getConfig(options)

--- a/packages/cli/src/contract.test.ts
+++ b/packages/cli/src/contract.test.ts
@@ -1,0 +1,85 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { getParents, loadSourceInfos, buildDependencies } from './contract'
+
+describe('contract', () => {
+  it('should get parents', async () => {
+    async function test(source: string) {
+      const sourceInfos = await loadSourceInfos('', '', source, false)
+      return getParents(sourceInfos)
+    }
+
+    expect(await test('Contract A() {}')).toEqual(new Map([['A', []]]))
+    expect(await test('Contract A() extends B() {}')).toEqual(new Map([['A', ['B']]]))
+    expect(await test('Contract A() extends B(), C() {}')).toEqual(new Map([['A', ['B', 'C']]]))
+    expect(await test('Contract A() extends B(), C() implements D, E {}')).toEqual(
+      new Map([['A', ['B', 'C', 'D', 'E']]])
+    )
+    expect(await test('Abstract Contract A() {}')).toEqual(new Map([['A', []]]))
+    expect(await test('Abstract Contract A() extends B() {}')).toEqual(new Map([['A', ['B']]]))
+    expect(await test('Abstract Contract A() extends B(), C() {}')).toEqual(new Map([['A', ['B', 'C']]]))
+    expect(await test('Abstract Contract A() extends B(), C() implements D, E {}')).toEqual(
+      new Map([['A', ['B', 'C', 'D', 'E']]])
+    )
+    expect(await test('Interface A extends B {}')).toEqual(new Map([['A', ['B']]]))
+    expect(await test('Interface A extends B, C {}')).toEqual(new Map([['A', ['B', 'C']]]))
+    const defs = [
+      'Interface A {}',
+      'Interface B implements A {}',
+      'Abstract Contract C() {}',
+      'Abstract Contract D(mut a: U256) extends C() {}',
+      'Contract E(@unused mut a: U256, b: [U256; 2]) extends D(a) {}'
+    ]
+    expect(await test(defs.join('\n'))).toEqual(
+      new Map([
+        ['A', []],
+        ['B', ['A']],
+        ['C', []],
+        ['D', ['C']],
+        ['E', ['D']]
+      ])
+    )
+  })
+
+  it('should build dependencies', async () => {
+    async function test(source: string) {
+      const sourceInfos = await loadSourceInfos('', '', source, false)
+      return buildDependencies(sourceInfos)
+    }
+    const defs0 = [
+      'Interface A {}',
+      'Interface B implements A {}',
+      'Abstract Contract C() implements B {}',
+      'Abstract Contract D(mut a: U256) extends C() {}',
+      'Contract E(@unused mut a: U256, b: [U256; 2]) extends D(a) {}'
+    ]
+    expect(await test(defs0.join('\n'))).toEqual(
+      new Map([
+        ['A', []],
+        ['B', ['A']],
+        ['C', ['B', 'A']],
+        ['D', ['C', 'B', 'A']],
+        ['E', ['D', 'C', 'B', 'A']]
+      ])
+    )
+
+    const defs1 = ['Interface A implements B {}', 'Interface B implements A {}']
+    await expect(test(defs1.join('\n'))).rejects.toThrow('Circular dependency detected: A')
+  })
+})

--- a/packages/cli/src/contract.ts
+++ b/packages/cli/src/contract.ts
@@ -1,0 +1,135 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { WebCrypto } from '@alephium/web3'
+import * as path from 'path'
+
+const crypto = new WebCrypto()
+
+export enum SourceKind {
+  Contract = 0,
+  Script = 1,
+  AbstractContract = 2,
+  Interface = 3,
+  Struct = 4,
+  Constants = 5
+}
+
+class TypedMatcher<T extends SourceKind> {
+  matcher: RegExp
+  type: T
+
+  constructor(pattern: string, type: T) {
+    this.matcher = new RegExp(pattern, 'mg')
+    this.type = type
+  }
+}
+
+function removeParentsPrefix(parts: string[]): string {
+  let index = 0
+  for (let i = 0; i < parts.length; i++) {
+    if (parts[`${i}`] === '..') {
+      index += 1
+    } else {
+      break
+    }
+  }
+  return path.join(...parts.slice(index))
+}
+
+export class SourceInfo {
+  type: SourceKind
+  name: string
+  contractRelativePath: string
+  sourceCode: string
+  sourceCodeHash: string
+  isExternal: boolean
+
+  getArtifactPath(artifactsRootDir: string): string {
+    let fullPath: string
+    if (this.isExternal) {
+      const relativePath = removeParentsPrefix(this.contractRelativePath.split(path.sep))
+      const externalPath = path.join('.external', relativePath)
+      fullPath = path.join(artifactsRootDir, externalPath)
+    } else {
+      fullPath = path.join(artifactsRootDir, this.contractRelativePath)
+    }
+    return path.join(path.dirname(fullPath), `${this.name}.ral.json`)
+  }
+
+  constructor(
+    type: SourceKind,
+    name: string,
+    sourceCode: string,
+    sourceCodeHash: string,
+    contractRelativePath: string,
+    isExternal: boolean
+  ) {
+    this.type = type
+    this.name = name
+    this.sourceCode = sourceCode
+    this.sourceCodeHash = sourceCodeHash
+    this.contractRelativePath = contractRelativePath
+    this.isExternal = isExternal
+  }
+
+  static async from(
+    type: SourceKind,
+    name: string,
+    sourceCode: string,
+    contractRelativePath: string,
+    isExternal: boolean
+  ): Promise<SourceInfo> {
+    const sourceCodeHash = await crypto.subtle.digest('SHA-256', Buffer.from(sourceCode))
+    const sourceCodeHashHex = Buffer.from(sourceCodeHash).toString('hex')
+    return new SourceInfo(type, name, sourceCode, sourceCodeHashHex, contractRelativePath, isExternal)
+  }
+}
+
+const abstractContractMatcher = new TypedMatcher<SourceKind>(
+  '^Abstract Contract ([A-Z][a-zA-Z0-9]*)',
+  SourceKind.AbstractContract
+)
+const contractMatcher = new TypedMatcher('^Contract ([A-Z][a-zA-Z0-9]*)', SourceKind.Contract)
+const interfaceMatcher = new TypedMatcher('^Interface ([A-Z][a-zA-Z0-9]*)', SourceKind.Interface)
+const scriptMatcher = new TypedMatcher('^TxScript ([A-Z][a-zA-Z0-9]*)', SourceKind.Script)
+const structMatcher = new TypedMatcher('struct ([A-Z][a-zA-Z0-9]*)', SourceKind.Struct)
+const matchers = [abstractContractMatcher, contractMatcher, interfaceMatcher, scriptMatcher, structMatcher]
+
+export async function loadSourceInfos(
+  relativePath: string,
+  sourcePath: string,
+  sourceCode: string,
+  isExternal: boolean
+): Promise<SourceInfo[]> {
+  let isConstantsFile = true
+  const sourceInfos: SourceInfo[] = []
+  for (const matcher of matchers) {
+    const results = Array.from(sourceCode.matchAll(matcher.matcher))
+    if (isConstantsFile) isConstantsFile = results.length === 0
+    for (const result of results) {
+      const sourceInfo = await SourceInfo.from(matcher.type, result[1], sourceCode, relativePath, isExternal)
+      sourceInfos.push(sourceInfo)
+    }
+  }
+  if (isConstantsFile) {
+    const name = path.basename(sourcePath, path.extname(sourcePath))
+    sourceInfos.push(await SourceInfo.from(SourceKind.Constants, name, sourceCode, relativePath, false))
+  }
+  return sourceInfos
+}

--- a/packages/cli/src/project.test.ts
+++ b/packages/cli/src/project.test.ts
@@ -17,7 +17,8 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { DEFAULT_NODE_COMPILER_OPTIONS } from '@alephium/web3'
-import { CodeInfo, ProjectArtifact, SourceInfo } from './project'
+import { CodeInfo, ProjectArtifact } from './project'
+import { SourceInfo } from './contract'
 
 describe('project', () => {
   function newCodeInfo(hash: string): CodeInfo {
@@ -30,7 +31,7 @@ describe('project', () => {
   }
 
   function newSourceInfo(name: string, hash: string): SourceInfo {
-    return new SourceInfo(0, name, '', hash, '', false)
+    return new SourceInfo(0, name, undefined, '', hash, '', false)
   }
 
   it('should get changed sources', () => {

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -26,7 +26,6 @@ import {
   Struct,
   node,
   web3,
-  WebCrypto,
   CompilerOptions,
   Constant,
   Enum,
@@ -38,89 +37,9 @@ import fs from 'fs'
 import { promises as fsPromises } from 'fs'
 import { parseError } from './error'
 import * as fetchRetry from 'fetch-retry'
+import { SourceInfo, SourceKind, loadSourceInfos } from './contract'
 
-const crypto = new WebCrypto()
 const defaultMainnetNodeUrl = 'https://node.mainnet.alephium.org'
-
-class TypedMatcher<T extends SourceKind> {
-  matcher: RegExp
-  type: T
-
-  constructor(pattern: string, type: T) {
-    this.matcher = new RegExp(pattern, 'mg')
-    this.type = type
-  }
-}
-
-function removeParentsPrefix(parts: string[]): string {
-  let index = 0
-  for (let i = 0; i < parts.length; i++) {
-    if (parts[`${i}`] === '..') {
-      index += 1
-    } else {
-      break
-    }
-  }
-  return path.join(...parts.slice(index))
-}
-
-enum SourceKind {
-  Contract = 0,
-  Script = 1,
-  AbstractContract = 2,
-  Interface = 3,
-  Struct = 4,
-  Constants = 5
-}
-
-export class SourceInfo {
-  type: SourceKind
-  name: string
-  contractRelativePath: string
-  sourceCode: string
-  sourceCodeHash: string
-  isExternal: boolean
-
-  getArtifactPath(artifactsRootDir: string): string {
-    let fullPath: string
-    if (this.isExternal) {
-      const relativePath = removeParentsPrefix(this.contractRelativePath.split(path.sep))
-      const externalPath = path.join('.external', relativePath)
-      fullPath = path.join(artifactsRootDir, externalPath)
-    } else {
-      fullPath = path.join(artifactsRootDir, this.contractRelativePath)
-    }
-    return path.join(path.dirname(fullPath), `${this.name}.ral.json`)
-  }
-
-  constructor(
-    type: SourceKind,
-    name: string,
-    sourceCode: string,
-    sourceCodeHash: string,
-    contractRelativePath: string,
-    isExternal: boolean
-  ) {
-    this.type = type
-    this.name = name
-    this.sourceCode = sourceCode
-    this.sourceCodeHash = sourceCodeHash
-    this.contractRelativePath = contractRelativePath
-    this.isExternal = isExternal
-  }
-
-  static async from(
-    type: SourceKind,
-    name: string,
-    sourceCode: string,
-    contractRelativePath: string,
-    isExternal: boolean
-  ): Promise<SourceInfo> {
-    const sourceCodeHash = await crypto.subtle.digest('SHA-256', Buffer.from(sourceCode))
-    const sourceCodeHashHex = Buffer.from(sourceCodeHash).toString('hex')
-    return new SourceInfo(type, name, sourceCode, sourceCodeHashHex, contractRelativePath, isExternal)
-  }
-}
 
 class Compiled<T extends Artifact> {
   sourceInfo: SourceInfo
@@ -312,22 +231,6 @@ export class Project {
   readonly artifactsRootDir: string
 
   static readonly importRegex = new RegExp('^import "[^"./]+/[^"]*[a-z][a-z_0-9]*(.ral)?"', 'mg')
-  static readonly abstractContractMatcher = new TypedMatcher<SourceKind>(
-    '^Abstract Contract ([A-Z][a-zA-Z0-9]*)',
-    SourceKind.AbstractContract
-  )
-  static readonly contractMatcher = new TypedMatcher('^Contract ([A-Z][a-zA-Z0-9]*)', SourceKind.Contract)
-  static readonly interfaceMatcher = new TypedMatcher('^Interface ([A-Z][a-zA-Z0-9]*)', SourceKind.Interface)
-  static readonly scriptMatcher = new TypedMatcher('^TxScript ([A-Z][a-zA-Z0-9]*)', SourceKind.Script)
-  static readonly structMatcher = new TypedMatcher('struct ([A-Z][a-zA-Z0-9]*)', SourceKind.Struct)
-  static readonly matchers = [
-    Project.abstractContractMatcher,
-    Project.contractMatcher,
-    Project.interfaceMatcher,
-    Project.scriptMatcher,
-    Project.structMatcher
-  ]
-
   static readonly structArtifactFileName = 'structs.ral.json'
   static readonly constantArtifactFileName = 'constants.ral.json'
 
@@ -895,21 +798,8 @@ export class Project {
     if (sourceStr.match(new RegExp('^import "', 'mg')) !== null) {
       throw new Error(`Invalid import statements, source: ${sourcePath}`)
     }
-    const sourceInfos = externalSourceInfos
-    let isConstantsFile = true
-    for (const matcher of this.matchers) {
-      const results = Array.from(sourceStr.matchAll(matcher.matcher))
-      if (isConstantsFile) isConstantsFile = results.length === 0
-      for (const result of results) {
-        const sourceInfo = await SourceInfo.from(matcher.type, result[1], sourceStr, contractRelativePath, isExternal)
-        sourceInfos.push(sourceInfo)
-      }
-    }
-    if (isConstantsFile) {
-      const name = path.basename(sourcePath, path.extname(sourcePath))
-      sourceInfos.push(await SourceInfo.from(SourceKind.Constants, name, sourceStr, contractRelativePath, false))
-    }
-    return sourceInfos
+    const sourceInfos = await loadSourceInfos(contractRelativePath, sourcePath, sourceStr, isExternal)
+    return externalSourceInfos.concat(sourceInfos)
   }
 
   private static async loadSourceFiles(projectRootDir: string, contractsRootDir: string): Promise<SourceInfo[]> {


### PR DESCRIPTION
1. When contract `A` extends the abstract contract `B`, if B's code changes, we should be able to recompile contract `A`
2. Add a `--force` flag to the compile command in the CLI