### PR TITLE
Fix `NonExistInput` Error During Chained Txs Submission

### DIFF
--- a/packages/web3/src/block/index.ts
+++ b/packages/web3/src/block/index.ts
@@ -16,4 +16,4 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-export { ReorgCallback, BlockSubscribeOptions, BlockSubscription } from './block'
+export { ReorgCallback, BlockSubscribeOptions, BlockSubscription, waitForBlockFromGroupAndRetry } from './block'


### PR DESCRIPTION
When submitting the chained transactions, it is possible that the input doesn't exist yet because a new block isn't produced with the `fromGroup`. 

Here in `signAndSubmitChainedTx`, if we detect that the full node returns the `NonExistInput` error, we try to wait for a block with `fromGroup` to be produced and try again. 