### PR TITLE
Improve TransactionBuilder to support calling contracts with groupless addresses

### DIFF
--- a/packages/web3/src/contract/ralph.test.ts
+++ b/packages/web3/src/contract/ralph.test.ts
@@ -470,36 +470,6 @@ describe('contract', function () {
     expect(utils.binToHex(ralph.encodeMapKey('00112233', 'ByteVec'))).toEqual('00112233')
   })
 
-  it('should update fields with group', () => {
-    const groupedAddress = '15EM5rGtt7dPRZScE4Z9oL2EDfj84JnoSgq3NNgdcGFyu'
-    expect(groupOfAddress(groupedAddress)).toEqual(0)
-    const grouplessAddress = '3cUqhqEgt8qFAokkD7qRsy9Q2Q9S1LEiSdogbBmaq7CnshB8BdjfK'
-    expect(groupOfAddress(grouplessAddress)).toEqual(2)
-
-    expect(ralph.updateFieldsWithGroup({ sender: groupedAddress }, 1)).toEqual({ sender: groupedAddress })
-    expect(ralph.updateFieldsWithGroup({ sender: grouplessAddress }, 1)).toEqual({ sender: `${grouplessAddress}:1` })
-    expect(ralph.updateFieldsWithGroup({ sender: `${grouplessAddress}:2` }, 1)).toEqual({
-      sender: `${grouplessAddress}:2`
-    })
-    expect(
-      ralph.updateFieldsWithGroup({ bytes: '0011', isValid: true, amount: '1000', address: grouplessAddress }, 1)
-    ).toEqual({
-      bytes: '0011',
-      isValid: true,
-      amount: '1000',
-      address: `${grouplessAddress}:1`
-    })
-    expect(ralph.updateFieldsWithGroup({ addresses: [groupedAddress, groupedAddress] }, 1)).toEqual({
-      addresses: [groupedAddress, groupedAddress]
-    })
-    expect(ralph.updateFieldsWithGroup({ addresses: [groupedAddress, grouplessAddress] }, 1)).toEqual({
-      addresses: [groupedAddress, `${grouplessAddress}:1`]
-    })
-    expect(ralph.updateFieldsWithGroup({ addresses: [grouplessAddress, grouplessAddress] }, 1)).toEqual({
-      addresses: [`${grouplessAddress}:1`, `${grouplessAddress}:1`]
-    })
-  })
-
   // it('should test buildByteCode', async () => {
   //   const compiled = {
   //     type: 'TemplateContractByteCode',

--- a/packages/web3/src/contract/ralph.ts
+++ b/packages/web3/src/contract/ralph.ts
@@ -399,32 +399,6 @@ function checkPrimitiveValue(name: string, ralphType: string, value: Val): strin
   throw Error(`Invalid value ${value} for ${name}, expected a value of type ${ralphType}`)
 }
 
-export function updateFieldsWithGroup(fields: Fields, group: number): Fields {
-  const newFields: Fields = {}
-  for (const key in fields) {
-    const value = fields[`${key}`]
-    newFields[`${key}`] = updateValWithGroup(value, group)
-  }
-  return newFields
-}
-
-function updateValWithGroup(value: Val, group: number): Val {
-  if (typeof value === 'string') {
-    if (!isValidAddress(value)) return value
-    if (isGrouplessAddressWithoutGroupIndex(value)) return `${value}:${group}`
-    return value
-  }
-
-  if (Array.isArray(value)) {
-    return value.map((v) => updateValWithGroup(v, group))
-  }
-
-  if (typeof value === 'object') {
-    return updateFieldsWithGroup(value as Fields, group)
-  }
-  return value
-}
-
 const scriptFieldRegex = /\{([0-9]*)\}/g
 
 export function buildScriptByteCode(

--- a/packages/web3/src/signer/tx-builder.test.ts
+++ b/packages/web3/src/signer/tx-builder.test.ts
@@ -1,0 +1,68 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { getGroupFromTxScript, updateBytecodeWithGroup } from './tx-builder'
+import { DestroyAdd } from '../../../../artifacts/ts/scripts'
+import { randomBytes } from 'crypto'
+import { binToHex } from '../utils'
+import { TOTAL_NUMBER_OF_GROUPS } from '../constants'
+import { groupOfAddress } from '../address'
+
+describe('tx-builder', () => {
+  function randomContractId(groupIndex: number): string {
+    const bytes = new Uint8Array([...randomBytes(31), groupIndex])
+    return binToHex(bytes)
+  }
+
+  it('should get group from tx script', () => {
+    const caller = '15EM5rGtt7dPRZScE4Z9oL2EDfj84JnoSgq3NNgdcGFyu'
+
+    for (let group = 0; group < TOTAL_NUMBER_OF_GROUPS; group += 1) {
+      const contractId = randomContractId(group)
+      const bytecode = DestroyAdd.script.buildByteCodeToDeploy({
+        add: contractId,
+        caller
+      })
+      expect(getGroupFromTxScript(bytecode)).toBe(group)
+    }
+  })
+
+  it('should update bytecode with group', () => {
+    const caller = '3cUs6NYx4yS3n3t4ukgDcvHxvoer4i1tag2sJvEaadUjRottEiujx'
+    const defaultGroup = groupOfAddress(caller)
+    expect(defaultGroup).toBe(1)
+
+    for (let group = 0; group < TOTAL_NUMBER_OF_GROUPS; group += 1) {
+      const contractId = randomContractId(group)
+      if (group === defaultGroup) {
+        const bytecode = DestroyAdd.script.buildByteCodeToDeploy({
+          add: contractId,
+          caller
+        })
+        expect(updateBytecodeWithGroup(bytecode, group)).toBe(bytecode)
+        continue
+      }
+
+      const bytecode = DestroyAdd.script.buildByteCodeToDeploy({
+        add: contractId,
+        caller
+      })
+      expect(updateBytecodeWithGroup(bytecode, group)).not.toBe(bytecode)
+    }
+  })
+})

--- a/packages/web3/src/signer/tx-builder.ts
+++ b/packages/web3/src/signer/tx-builder.ts
@@ -208,7 +208,7 @@ export abstract class TransactionBuilder {
   }
 
   private static checkAndGetParams(params: SignExecuteScriptTxParams): SignExecuteScriptTxParams {
-    if (isGroupedKeyType(params.signerKeyType ?? 'default') || params.group !== undefined) {
+    if (isGroupedKeyType(params.signerKeyType ?? 'default')) {
       return params
     }
 
@@ -216,7 +216,7 @@ export abstract class TransactionBuilder {
       throw new Error('Invalid signer key type for groupless address')
     }
 
-    const group = getGroupFromTxScript(params.bytecode)
+    const group = params.group ?? getGroupFromTxScript(params.bytecode)
     const defaultGroup = groupOfAddress(params.signerAddress)
     if (group === undefined || group === defaultGroup) {
       return { ...params, group: defaultGroup }

--- a/packages/web3/src/signer/tx-builder.ts
+++ b/packages/web3/src/signer/tx-builder.ts
@@ -18,7 +18,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { binToHex, hexToBinUnsafe } from '../utils'
 import { fromApiNumber256, node, NodeProvider, toApiNumber256Optional, toApiTokens } from '../api'
-import { addressFromPublicKey, contractIdFromAddress } from '../address'
+import { addressFromPublicKey, contractIdFromAddress, groupOfAddress, isGrouplessAddress } from '../address'
 import { toApiDestinations } from './signer'
 import {
   SignChainedTxParams,
@@ -36,7 +36,7 @@ import {
   SignUnsignedTxParams,
   SignUnsignedTxResult,
   BuildTxResult,
-  GrouplessBuildTxResult
+  isGroupedKeyType
 } from './types'
 import { unsignedTxCodec } from '../codec'
 import { groupIndexOfTransaction } from '../transaction'
@@ -47,6 +47,9 @@ import {
   BuildExecuteScriptTxResult,
   BuildTransferTxResult
 } from '../api/api-alephium'
+import { TOTAL_NUMBER_OF_GROUPS } from '../constants'
+import { scriptCodec } from '../codec/script-codec'
+import { LockupScript } from '../codec/lockup-script-codec'
 
 export abstract class TransactionBuilder {
   abstract get nodeProvider(): NodeProvider
@@ -204,13 +207,34 @@ export abstract class TransactionBuilder {
     }
   }
 
+  private static checkAndGetParams(params: SignExecuteScriptTxParams): SignExecuteScriptTxParams {
+    if (isGroupedKeyType(params.signerKeyType ?? 'default') || params.group !== undefined) {
+      return params
+    }
+
+    if (!isGrouplessAddress(params.signerAddress)) {
+      throw new Error('Invalid signer key type for groupless address')
+    }
+
+    const group = getGroupFromTxScript(params.bytecode)
+    const defaultGroup = groupOfAddress(params.signerAddress)
+    if (group === undefined || group === defaultGroup) {
+      return { ...params, group: defaultGroup }
+    }
+
+    const newBytecode = updateBytecodeWithGroup(params.bytecode, group)
+    const newParams = { ...params, bytecode: newBytecode }
+    return { ...newParams, group }
+  }
+
   private buildExecuteScriptTxParams(params: SignExecuteScriptTxParams, publicKey: string): node.BuildExecuteScriptTx {
     TransactionBuilder.validatePublicKey(params, publicKey, params.signerKeyType)
 
-    const { attoAlphAmount, tokens, gasPrice, dustAmount, ...rest } = params
+    const newParams = TransactionBuilder.checkAndGetParams(params)
+    const { signerKeyType, attoAlphAmount, tokens, gasPrice, dustAmount, ...rest } = newParams
     return {
       fromPublicKey: publicKey,
-      fromPublicKeyType: params.signerKeyType,
+      fromPublicKeyType: signerKeyType,
       attoAlphAmount: toApiNumber256Optional(attoAlphAmount),
       tokens: toApiTokens(tokens),
       gasPrice: toApiNumber256Optional(gasPrice),
@@ -295,4 +319,48 @@ export abstract class TransactionBuilder {
       gasPrice: fromApiNumber256(result.gasPrice)
     }
   }
+}
+
+export function getGroupFromTxScript(bytecode: string): number | undefined {
+  const script = scriptCodec.decode(hexToBinUnsafe(bytecode))
+  const instrs = script.methods.flatMap((method) => method.instrs)
+  for (let index = 0; index < instrs.length - 1; index += 1) {
+    const instr = instrs[`${index}`]
+    const nextInstr = instrs[index + 1]
+    if (
+      instr.name === 'BytesConst' &&
+      instr.value.length === 32 &&
+      (nextInstr.name === 'CallExternal' || nextInstr.name === 'CallExternalBySelector')
+    ) {
+      const groupIndex = instr.value[instr.value.length - 1]
+      if (groupIndex >= 0 && groupIndex < TOTAL_NUMBER_OF_GROUPS) {
+        return groupIndex
+      }
+    }
+  }
+  for (const instr of instrs) {
+    if (instr.name === 'BytesConst' && instr.value.length === 32) {
+      const groupIndex = instr.value[instr.value.length - 1]
+      if (groupIndex >= 0 && groupIndex < TOTAL_NUMBER_OF_GROUPS) {
+        return groupIndex
+      }
+    }
+  }
+  return undefined
+}
+
+export function updateBytecodeWithGroup(bytecode: string, group: number): string {
+  const script = scriptCodec.decode(hexToBinUnsafe(bytecode))
+  const newMethods = script.methods.map((method) => {
+    const newInstrs = method.instrs.map((instr) => {
+      if (instr.name === 'AddressConst' && instr.value.kind === 'P2PK') {
+        const newLockupScript: LockupScript = { ...instr.value, value: { ...instr.value.value, group } }
+        return { ...instr, value: newLockupScript }
+      }
+      return instr
+    })
+    return { ...method, instrs: newInstrs }
+  })
+  const bytes = scriptCodec.encode({ methods: newMethods })
+  return binToHex(bytes)
 }

--- a/test/contract.test.ts
+++ b/test/contract.test.ts
@@ -1074,7 +1074,7 @@ describe('contract', function () {
         from: grouplessSigner.address,
         value: { id: 1n, balance: 10n }
       })
-      grouplessSigner.signAndSubmitExecuteScriptTx({
+      await grouplessSigner.signAndSubmitExecuteScriptTx({
         signerAddress: grouplessSigner.address,
         signerKeyType: grouplessSigner.account.keyType,
         bytecode: bytecode,


### PR DESCRIPTION
Currently, we have only checked the bytecode and the group in `Script` to support groupless addresses, but the following two situations would still fail:

1. A dApp directly uses `TransactionBuilder` to construct a transaction.
2. A dApp sends a request to the wallet via `WalletConnect`, and the wallet uses `TransactionBuilder` to construct the transaction (which means that once this PR is merged, the wallet will need to update to the latest version of the SDK).

This PR addresses these issues. Additionally, to ensure that the current version of the wallet still works, we need to keep the support in `Script`.