### PR TITLE
Rename connector when mobile detected

### DIFF
--- a/packages/web3-react/src/constants/supportedConnectors.tsx
+++ b/packages/web3-react/src/constants/supportedConnectors.tsx
@@ -16,16 +16,19 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 import { Connector } from '../types'
+import { isMobile } from '../utils'
 import Logos from './../assets/logos'
 
 let supportedConnectors: Connector[] = []
+
+const _isMobile = isMobile()
 
 if (typeof window != 'undefined') {
   supportedConnectors = [
     {
       id: 'injected',
-      name: 'Extension Wallet',
-      shortName: 'Browser',
+      name: _isMobile ? 'Mobile wallet' : 'Extension wallet',
+      shortName: _isMobile ? 'Mobile' : 'Browser',
       logos: {
         default: <Logos.AlephiumIcon />,
         mobile: (


### PR DESCRIPTION
The mobile wallet uses the same injector as the extension wallet to connect to the dApp within its in-app browser. It is confusing for the user to press the `Browser` or `Extension wallet`button to connect with the mobile wallet. So far we mitigated this issue by showing a message to the user:

> Useful tip 💡
> For a smoother experience when connecting to a dApp, use the **Browser/Extension** button instead of WalletConnect.

However, this is also not optimal. Best option is to attack the problem at its root:

**When we detect that the dApp is in a mobile device, rename the connector**

This PR does just that, simply renames the connector based on the platform the dApp is loaded in. This will simplify the mobile wallet experience a lot.

| before | after |
| ----- | ----- |
| <img width="391" height="680" alt="image" src="https://github.com/user-attachments/assets/593ee93a-6192-493d-a4cc-bd71a5beaffd" /> | <img width="392" height="682" alt="image" src="https://github.com/user-attachments/assets/332a3235-7fe4-4c8a-a1c0-65452afe4bae" /> |