### PR TITLE
Skip tests on deploy

### DIFF
--- a/packages/cli/src/deployment.ts
+++ b/packages/cli/src/deployment.ts
@@ -597,7 +597,7 @@ export async function deploy<Settings = unknown>(
   let project: Project | undefined = undefined
   if (configuration.skipRecompileOnDeployment !== true) {
     project = await Project.compile(
-      configuration.compilerOptions,
+      { ...(configuration.compilerOptions ?? {}), skipTests: true },
       path.resolve(process.cwd()),
       configuration.sourceDir ?? DEFAULT_CONFIGURATION_VALUES.sourceDir,
       artifactDir,


### PR DESCRIPTION
The test instrs are not available on testnet/mainnet, so we should skip tests on deploy