### PR TITLE
Add auto-connect retry for late-arriving wallet providers

### DIFF
--- a/packages/get-extension-wallet/package.json
+++ b/packages/get-extension-wallet/package.json
@@ -38,7 +38,7 @@
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^4.2.1",
     "husky": "^8.0.3",
-    "postcss": "^8.4.31",
+    "postcss": "^8.5.10",
     "prettier": "^2.8.7",
     "rollup": "^2.79.2",
     "rollup-plugin-delete": "^2.0.0",

--- a/packages/web3-react/.eslintrc
+++ b/packages/web3-react/.eslintrc
@@ -4,5 +4,6 @@
   "rules": {
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "error"
-  }
+  },
+  "ignorePatterns": ["vitest.config.ts"]
 }

--- a/packages/web3-react/package.json
+++ b/packages/web3-react/package.json
@@ -31,7 +31,8 @@
     "build": "rollup --config rollup.config.prod.js",
     "clean": "rm -rf build",
     "clean:all": "pnpm clean && rm -rf node_modules",
-    "lint": "eslint src --ext .ts,tsx"
+    "lint": "eslint src --ext .ts,tsx",
+    "test": "vitest run"
   },
   "keywords": [
     "react-hook",
@@ -66,16 +67,16 @@
     "@types/react-dom": "^18.0.11",
     "@types/styled-components": "^5.1.26",
     "@types/use-sync-external-store": "^0.0.6",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "happy-dom": "^20.9.0",
+    "vitest": "^3.1.1",
     "rollup": "^2.79.2",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.37.0",
     "rollup-plugin-visualizer": "^5.9.0",
     "typescript": "^5.9.3"
-  },
-  "resolutions": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
   }
 }

--- a/packages/web3-react/src/components/AlephiumConnect.tsx
+++ b/packages/web3-react/src/components/AlephiumConnect.tsx
@@ -48,6 +48,7 @@ import {
 import { getLastConnectedAccount, removeLastConnectedAccount } from '../utils/storage'
 import { Connectors, ConnectResult, createDefaultConnectors } from '../utils/connector'
 import { useInjectedProviders } from '../hooks/useInjectedProviders'
+import { injectedProviderStore } from '../utils/injectedProviders'
 import { isCompatibleAddressGroup } from '@alephium/walletconnect-provider'
 
 export const ConnectSettingProvider: React.FC<{
@@ -186,17 +187,22 @@ export const AlephiumConnectProvider: React.FC<{
   )
 
   useEffect(() => {
-    const func = async () => {
-      const onDisconnected = () => {
-        removeLastConnectedAccount()
-        updateAccount(undefined)
-        updateSignerProvider(undefined)
-      }
-      const onConnected = (result: ConnectResult) => {
-        updateAccount(result.account)
-        updateSignerProvider(result.signerProvider)
-      }
+    let cancelled = false
+    let retrying = false
+    let unsubscribe: (() => void) | undefined
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
 
+    const onDisconnected = () => {
+      removeLastConnectedAccount()
+      updateAccount(undefined)
+      updateSignerProvider(undefined)
+    }
+    const onConnected = (result: ConnectResult) => {
+      updateAccount(result.account)
+      updateSignerProvider(result.signerProvider)
+    }
+
+    const tryAutoConnect = async (): Promise<boolean> => {
       try {
         const lastConnectorId = lastConnectedAccount?.connectorId
         const allConnectorIds = Array.from(connectorIds)
@@ -216,18 +222,61 @@ export const AlephiumConnectProvider: React.FC<{
               onConnected
             })
             if (result !== undefined) {
-              return
+              return true
             }
           }
         }
       } catch (error) {
         console.error(error)
       }
-
-      onDisconnected()
+      return false
     }
 
-    func()
+    const cleanup = () => {
+      if (unsubscribe) {
+        unsubscribe()
+        unsubscribe = undefined
+      }
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId)
+        timeoutId = undefined
+      }
+    }
+
+    const run = async () => {
+      const connected = await tryAutoConnect()
+      if (cancelled) return
+
+      if (connected) {
+        return
+      }
+
+      // Initial attempt failed; subscribe for late-arriving providers
+      unsubscribe = injectedProviderStore.subscribe(() => {
+        if (cancelled || retrying) return
+        retrying = true
+        tryAutoConnect().then((success) => {
+          retrying = false
+          if (cancelled) return
+          if (success) {
+            cleanup()
+          }
+        })
+      })
+
+      timeoutId = setTimeout(() => {
+        if (cancelled) return
+        cleanup()
+        onDisconnected()
+      }, 3000)
+    }
+
+    run()
+
+    return () => {
+      cancelled = true
+      cleanup()
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 

--- a/packages/web3-react/src/components/__tests__/AlephiumConnect.test.tsx
+++ b/packages/web3-react/src/components/__tests__/AlephiumConnect.test.tsx
@@ -1,0 +1,297 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-non-null-assertion */
+
+import React, { useContext } from 'react'
+import { render, act, cleanup } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { AlephiumConnectContext, AlephiumConnectContextValue } from '../../contexts/alephiumConnect'
+import { ConnectResult, Connectors } from '../../utils/connector'
+
+// ---- Mocks ----
+
+const subscribeListeners: Set<(providers: any[]) => void> = new Set()
+const mockSubscribe = vi.fn((listener: (providers: any[]) => void) => {
+  subscribeListeners.add(listener)
+  return () => {
+    subscribeListeners.delete(listener)
+  }
+})
+const mockGetProviders = vi.fn(() => [] as any[])
+
+vi.mock('../../utils/injectedProviders', () => ({
+  injectedProviderStore: {
+    subscribe: (listener: any) => mockSubscribe(listener),
+    getProviders: () => mockGetProviders()
+  },
+  getInjectedProviderId: () => 'Alephium',
+  getInjectedProvider: () => undefined
+}))
+
+const mockGetLastConnectedAccount = vi.fn()
+const mockSetLastConnectedAccount = vi.fn()
+const mockRemoveLastConnectedAccount = vi.fn()
+
+vi.mock('../../utils/storage', () => ({
+  getLastConnectedAccount: (...args: any[]) => mockGetLastConnectedAccount(...args),
+  setLastConnectedAccount: (...args: any[]) => mockSetLastConnectedAccount(...args),
+  removeLastConnectedAccount: (...args: any[]) => mockRemoveLastConnectedAccount(...args)
+}))
+
+const mockAutoConnect = vi.fn()
+const mockConnect = vi.fn()
+const mockDisconnect = vi.fn()
+
+function makeConnectors(): Connectors {
+  return {
+    injected: {
+      connect: mockConnect,
+      disconnect: mockDisconnect,
+      autoConnect: mockAutoConnect
+    },
+    walletConnect: {
+      connect: mockConnect,
+      disconnect: mockDisconnect
+    },
+    desktopWallet: {
+      connect: mockConnect,
+      disconnect: mockDisconnect
+    }
+  }
+}
+
+vi.mock('../../utils/connector', () => ({
+  createDefaultConnectors: () => makeConnectors()
+}))
+
+// Mock useInjectedProviders to return an empty array
+vi.mock('../../hooks/useInjectedProviders', () => ({
+  useInjectedProviders: () => []
+}))
+
+// Mock isCompatibleAddressGroup to always return true
+vi.mock('@alephium/walletconnect-provider', () => ({
+  isCompatibleAddressGroup: () => true
+}))
+
+// ---- Import the component under test after mocks ----
+// eslint-disable-next-line
+import { AlephiumConnectProvider } from '../AlephiumConnect'
+
+// ---- Test Helper ----
+
+function TestConsumer({ onRender }: { onRender: (ctx: AlephiumConnectContextValue) => void }) {
+  const ctx = useContext(AlephiumConnectContext)
+  if (ctx) onRender(ctx)
+  return null
+}
+
+const fakeAccount = {
+  address: '1DrDyTr9RpRsQnDnXo2YRiPzPW4ooHX5LLoqXrqfMrpQH',
+  publicKey: 'abc123',
+  keyType: 'default' as const,
+  group: 0
+}
+
+const fakeSignerProvider = { nodeProvider: {} } as any
+
+describe('AlephiumConnect auto-connect retry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    subscribeListeners.clear()
+
+    // Default: last connected account exists (so auto-connect is attempted)
+    mockGetLastConnectedAccount.mockReturnValue({
+      connectorId: 'injected',
+      account: fakeAccount,
+      network: 'mainnet'
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+  })
+
+  it('connects immediately when provider is available on first attempt', async () => {
+    mockAutoConnect.mockImplementation(async (opts: any) => {
+      await opts.onConnected({ account: fakeAccount, signerProvider: fakeSignerProvider } as ConnectResult)
+      return fakeAccount
+    })
+
+    let latestCtx: AlephiumConnectContextValue | undefined
+
+    await act(() => {
+      render(
+        <AlephiumConnectProvider network="mainnet">
+          <TestConsumer
+            onRender={(ctx) => {
+              latestCtx = ctx
+            }}
+          />
+        </AlephiumConnectProvider>
+      )
+    })
+
+    expect(latestCtx!.connectionStatus).toBe('connected')
+    expect(latestCtx!.account?.address).toBe(fakeAccount.address)
+    // Store subscribe should not have active listeners (no retry needed)
+    expect(subscribeListeners.size).toBe(0)
+  })
+
+  it('connects when provider arrives late (within timeout)', async () => {
+    let callCount = 0
+    mockAutoConnect.mockImplementation(async (opts: any) => {
+      callCount++
+      if (callCount === 1) {
+        // First attempt fails
+        return undefined
+      }
+      // Second attempt succeeds
+      await opts.onConnected({ account: fakeAccount, signerProvider: fakeSignerProvider } as ConnectResult)
+      return fakeAccount
+    })
+
+    let latestCtx: AlephiumConnectContextValue | undefined
+
+    await act(() => {
+      render(
+        <AlephiumConnectProvider network="mainnet">
+          <TestConsumer
+            onRender={(ctx) => {
+              latestCtx = ctx
+            }}
+          />
+        </AlephiumConnectProvider>
+      )
+    })
+
+    // After initial failed attempt, status should still be 'connecting'
+    expect(latestCtx!.connectionStatus).toBe('connecting')
+    // A subscription should be active
+    expect(subscribeListeners.size).toBe(1)
+
+    // Simulate a late-arriving provider
+    await act(() => {
+      subscribeListeners.forEach((listener) => listener([{ id: 'alephium' }]))
+    })
+
+    expect(latestCtx!.connectionStatus).toBe('connected')
+    expect(latestCtx!.account?.address).toBe(fakeAccount.address)
+    // Subscription should be cleaned up after success
+    expect(subscribeListeners.size).toBe(0)
+  })
+
+  it('disconnects when provider never arrives (timeout)', async () => {
+    mockAutoConnect.mockResolvedValue(undefined)
+
+    let latestCtx: AlephiumConnectContextValue | undefined
+
+    await act(() => {
+      render(
+        <AlephiumConnectProvider network="mainnet">
+          <TestConsumer
+            onRender={(ctx) => {
+              latestCtx = ctx
+            }}
+          />
+        </AlephiumConnectProvider>
+      )
+    })
+
+    expect(latestCtx!.connectionStatus).toBe('connecting')
+
+    // Advance timers past the 3-second timeout
+    await act(() => {
+      vi.advanceTimersByTime(3000)
+    })
+
+    expect(latestCtx!.connectionStatus).toBe('disconnected')
+    expect(mockRemoveLastConnectedAccount).toHaveBeenCalled()
+    // Subscription should be cleaned up
+    expect(subscribeListeners.size).toBe(0)
+  })
+
+  it('cleans up on unmount during wait', async () => {
+    mockAutoConnect.mockResolvedValue(undefined)
+
+    let latestCtx: AlephiumConnectContextValue | undefined
+
+    let result: ReturnType<typeof render>
+    await act(() => {
+      result = render(
+        <AlephiumConnectProvider network="mainnet">
+          <TestConsumer
+            onRender={(ctx) => {
+              latestCtx = ctx
+            }}
+          />
+        </AlephiumConnectProvider>
+      )
+    })
+
+    expect(latestCtx!.connectionStatus).toBe('connecting')
+    expect(subscribeListeners.size).toBe(1)
+
+    // Unmount during wait
+    await act(() => {
+      result!.unmount()
+    })
+
+    // Subscription should be cleaned up
+    expect(subscribeListeners.size).toBe(0)
+
+    // Advancing timers should not cause errors
+    await act(() => {
+      vi.advanceTimersByTime(3000)
+    })
+
+    // No call to removeLastConnectedAccount since cleanup cancelled the timeout
+    const callsAfterUnmount = mockRemoveLastConnectedAccount.mock.calls.length
+    expect(callsAfterUnmount).toBe(0)
+  })
+
+  it('does not override explicit disconnect with retry', async () => {
+    let callCount = 0
+    mockAutoConnect.mockImplementation(async (opts: any) => {
+      callCount++
+      if (callCount === 1) {
+        return undefined
+      }
+      await opts.onConnected({ account: fakeAccount, signerProvider: fakeSignerProvider } as ConnectResult)
+      return fakeAccount
+    })
+
+    let latestCtx: AlephiumConnectContextValue | undefined
+
+    await act(() => {
+      render(
+        <AlephiumConnectProvider network="mainnet">
+          <TestConsumer
+            onRender={(ctx) => {
+              latestCtx = ctx
+            }}
+          />
+        </AlephiumConnectProvider>
+      )
+    })
+
+    expect(latestCtx!.connectionStatus).toBe('connecting')
+
+    // Simulate a late provider arriving and succeeding
+    await act(() => {
+      subscribeListeners.forEach((listener) => listener([{ id: 'alephium' }]))
+    })
+
+    expect(latestCtx!.connectionStatus).toBe('connected')
+
+    // Now explicitly disconnect
+    await act(() => {
+      latestCtx!.setSignerProvider(undefined)
+    })
+
+    expect(latestCtx!.connectionStatus).toBe('disconnected')
+
+    // The retry mechanism should not override this since subscriptions are cleaned up
+    expect(subscribeListeners.size).toBe(0)
+  })
+})

--- a/packages/web3-react/vitest.config.ts
+++ b/packages/web3-react/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',
+    include: ['src/**/*.test.{ts,tsx}', 'test/**/*.test.{ts,tsx}'],
+    globals: true
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.1.1
-        version: 3.2.4(@types/node@20.19.37)(jiti@2.6.1)(sass@1.98.0)(terser@5.46.1)
+        version: 3.2.4(@types/node@20.19.37)(happy-dom@20.9.0)(jiti@2.6.1)(sass@1.98.0)(terser@5.46.1)
 
   packages/cli:
     dependencies:
@@ -77,7 +77,7 @@ importers:
         version: 2.8.8
       vitest:
         specifier: ^3.1.1
-        version: 3.2.4(@types/node@20.19.37)(jiti@2.6.1)(sass@1.98.0)(terser@5.46.1)
+        version: 3.2.4(@types/node@20.19.37)(happy-dom@20.9.0)(jiti@2.6.1)(sass@1.98.0)(terser@5.46.1)
     devDependencies:
       '@types/node':
         specifier: ^20.0.0
@@ -266,7 +266,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.1.1
-        version: 3.2.4(@types/node@20.19.37)(jiti@2.6.1)(sass@1.98.0)(terser@5.46.1)
+        version: 3.2.4(@types/node@20.19.37)(happy-dom@20.9.0)(jiti@2.6.1)(sass@1.98.0)(terser@5.46.1)
 
   packages/web3:
     dependencies:
@@ -354,7 +354,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.1.1
-        version: 3.2.4(@types/node@20.19.37)(jiti@2.6.1)(sass@1.98.0)(terser@5.46.1)
+        version: 3.2.4(@types/node@20.19.37)(happy-dom@20.9.0)(jiti@2.6.1)(sass@1.98.0)(terser@5.46.1)
 
   packages/web3-react:
     dependencies:
@@ -404,6 +404,12 @@ importers:
       '@rollup/plugin-node-resolve':
         specifier: ^15.0.1
         version: 15.3.1(rollup@2.80.0)
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.37
@@ -425,6 +431,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^4.6.0
         version: 4.6.2(eslint@8.38.0)
+      happy-dom:
+        specifier: ^20.9.0
+        version: 20.9.0
       rollup:
         specifier: ^2.79.2
         version: 2.80.0
@@ -443,6 +452,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/node@20.19.37)(happy-dom@20.9.0)(jiti@2.6.1)(sass@1.98.0)(terser@5.46.1)
 
   packages/web3-test:
     dependencies:
@@ -467,7 +479,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.1.1
-        version: 3.2.4(@types/node@20.19.37)(jiti@2.6.1)(sass@1.98.0)(terser@5.46.1)
+        version: 3.2.4(@types/node@20.19.37)(happy-dom@20.9.0)(jiti@2.6.1)(sass@1.98.0)(terser@5.46.1)
 
   packages/web3-wallet:
     dependencies:
@@ -504,9 +516,12 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.1.1
-        version: 3.2.4(@types/node@20.19.37)(jiti@2.6.1)(sass@1.98.0)(terser@5.46.1)
+        version: 3.2.4(@types/node@20.19.37)(happy-dom@20.9.0)(jiti@2.6.1)(sass@1.98.0)(terser@5.46.1)
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
@@ -646,6 +661,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.22.15':
     resolution: {integrity: sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==}
@@ -1588,6 +1607,29 @@ packages:
   '@swc/types@0.1.5':
     resolution: {integrity: sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tsconfig/node10@1.0.9':
     resolution: {integrity: sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==}
 
@@ -1599,6 +1641,9 @@ packages:
 
   '@tsconfig/node16@1.0.3':
     resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -1675,6 +1720,12 @@ packages:
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@5.59.0':
     resolution: {integrity: sha512-p0QgrEyrxAWBecR56gyn3wkG15TJdI//eetInP3zYRewDh0XS+DhB3VUAd3QqvziFsfaQIoIuZMxZRB7vXYaYw==}
@@ -1945,6 +1996,13 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
@@ -2289,6 +2347,9 @@ packages:
   css-to-react-native@3.2.0:
     resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -2380,6 +2441,10 @@ packages:
     resolution: {integrity: sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==}
     engines: {node: '>=10'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
@@ -2419,6 +2484,12 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
@@ -2444,6 +2515,10 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -2945,6 +3020,10 @@ packages:
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
 
+  happy-dom@20.9.0:
+    resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
+    engines: {node: '>=20.0.0'}
+
   hard-rejection@2.1.0:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
     engines: {node: '>=6'}
@@ -3399,6 +3478,10 @@ packages:
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.27.0:
     resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
@@ -4715,6 +4798,10 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
@@ -4790,6 +4877,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
 
@@ -4846,6 +4945,8 @@ packages:
     engines: {node: '>=10'}
 
 snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
 
   '@adraffy/ens-normalize@1.11.1': {}
 
@@ -4910,7 +5011,7 @@ snapshots:
       debug: 4.4.3(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 7.7.4
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
@@ -5021,6 +5122,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/runtime@7.29.2': {}
 
   '@babel/template@7.22.15':
     dependencies:
@@ -5793,6 +5896,36 @@ snapshots:
 
   '@swc/types@0.1.5': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
   '@tsconfig/node10@1.0.9': {}
 
   '@tsconfig/node12@1.0.11': {}
@@ -5800,6 +5933,8 @@ snapshots:
   '@tsconfig/node14@1.0.3': {}
 
   '@tsconfig/node16@1.0.3': {}
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -5872,6 +6007,12 @@ snapshots:
   '@types/swagger-schema-official@2.0.22': {}
 
   '@types/use-sync-external-store@0.0.6': {}
+
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.37
 
   '@typescript-eslint/eslint-plugin@5.59.0(@typescript-eslint/parser@5.59.0(eslint@8.38.0)(typescript@5.9.3))(eslint@8.38.0)(typescript@5.9.3)':
     dependencies:
@@ -6354,6 +6495,12 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
   array-buffer-byte-length@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -6742,6 +6889,8 @@ snapshots:
       css-color-keywords: 1.0.0
       postcss-value-parser: 4.2.0
 
+  css.escape@1.5.1: {}
+
   csstype@3.2.3: {}
 
   dargs@7.0.0: {}
@@ -6822,6 +6971,8 @@ snapshots:
       rimraf: 3.0.2
       slash: 3.0.0
 
+  dequal@2.0.3: {}
+
   destr@2.0.5: {}
 
   detect-browser@5.2.0: {}
@@ -6851,6 +7002,10 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
   dot-prop@5.3.0:
     dependencies:
       is-obj: 2.0.0
@@ -6879,6 +7034,8 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  entities@7.0.1: {}
 
   environment@1.1.0: {}
 
@@ -7573,6 +7730,18 @@ snapshots:
       ufo: 1.6.3
       uncrypto: 0.1.3
 
+  happy-dom@20.9.0:
+    dependencies:
+      '@types/node': 20.19.37
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   hard-rejection@2.1.0: {}
 
   has-bigints@1.1.0: {}
@@ -7964,6 +8133,8 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+
+  lz-string@1.5.0: {}
 
   magic-string@0.27.0:
     dependencies:
@@ -9336,7 +9507,7 @@ snapshots:
       sass: 1.98.0
       terser: 5.46.1
 
-  vitest@3.2.4(@types/node@20.19.37)(jiti@2.6.1)(sass@1.98.0)(terser@5.46.1):
+  vitest@3.2.4(@types/node@20.19.37)(happy-dom@20.9.0)(jiti@2.6.1)(sass@1.98.0)(terser@5.46.1):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -9363,6 +9534,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.37
+      happy-dom: 20.9.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -9380,6 +9552,8 @@ snapshots:
   web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@3.0.1: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   whatwg-url@5.0.0:
     dependencies:
@@ -9463,6 +9637,8 @@ snapshots:
   ws@7.5.10: {}
 
   ws@8.18.2: {}
+
+  ws@8.20.0: {}
 
   y18n@4.0.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,8 +141,8 @@ importers:
         specifier: ^8.0.3
         version: 8.0.3
       postcss:
-        specifier: ^8.4.31
-        version: 8.5.8
+        specifier: ^8.5.10
+        version: 8.5.12
       prettier:
         specifier: ^2.8.7
         version: 2.8.8
@@ -3865,8 +3865,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
   preact@10.4.1:
@@ -8545,7 +8545,7 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.8:
+  postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -9497,7 +9497,7 @@ snapshots:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.8
+      postcss: 8.5.12
       rollup: 4.60.1
       tinyglobby: 0.2.15
     optionalDependencies:


### PR DESCRIPTION
The auto-connect useEffect in AlephiumConnectProvider runs once on
mount and gives up immediately if no provider is detected. Browser
extension content scripts sometimes inject after this effect fires,
causing intermittent "Connect wallet" states on page load despite the
wallet being installed.

After the initial auto-connect loop fails, subscribe to the injected
provider store and retry when new providers are discovered. Delay
calling onDisconnected() until a 3-second timeout expires, keeping
the UI in "connecting" state instead of flashing to "disconnected"
and back. Clean up the subscription and timeout on success, timeout
expiry, or component unmount.

Also set up test infrastructure (vitest, @testing-library/react,
happy-dom) and add integration tests covering: immediate connect,
late provider arrival, timeout fallback, unmount cleanup, and
explicit disconnect.
